### PR TITLE
Feature/#36 홈 생성/갱신/삭제 API 구현

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import cookieParser from "cookie-parser"; //쿠키 파싱
 import notificationRouter from "./routes/notification.route.js";
 import authRouter from "./routes/auth.route.js";
 import placeRouter from './routes/myPlace.route.js';
+import homeRouter from './routes/home.route.js';
 import { globalErrorHandler } from "./middleware/error.middleware.js";
 
 const app = express();
@@ -22,6 +23,7 @@ app.use(cors({
 //라우터
 app.use("/api/alerts", notificationRouter);
 app.use('/auth', authRouter);
+app.use("/api/myplaces/home", homeRouter);
 app.use("/api", placeRouter);
 
 app.get("/", (req, res) => {

--- a/src/controllers/home.controller.js
+++ b/src/controllers/home.controller.js
@@ -13,9 +13,10 @@ export const upsertHomeHandler = async(req, res, next) => {
             e.statusCode = 401;
             throw e;
         }
+        const userIdBigint = BigInt(userId);
 
         // 서비스 호출
-        const home = await upsertHomeMyPlace(userId, req.body);
+        const home = await upsertHomeMyPlace(userIdBigint, req.body);
 
         // 응답
         return res.status(200).json(
@@ -41,8 +42,10 @@ export const removeHomeHandler = async (req, res, next) => {
             throw e;
         }
         
+        const userIdBigint = BigInt(userId);
+
         // 서비스 호출
-        await deleteHomeMyPlace(userId);
+        await deleteHomeMyPlace(userIdBigint);
 
         // 응답
         return res.status(200).json(

--- a/src/controllers/home.controller.js
+++ b/src/controllers/home.controller.js
@@ -1,0 +1,60 @@
+// src/controllers/home.controller.js
+
+import { CustomSuccess } from '../response/customSuccess.js';
+import { CustomError } from '../response/customError.js';
+import { upsertHomeMyPlace, deleteHomeMyPlace } from '../services/home.service.js';
+
+// 홈 추가/수정(upsert)
+export const upsertHomeHandler = async(req, res, next) => {
+    try {
+        const userId = req.user.userId;
+        if (!userId) {
+            const e = new CustomError("UNAUTHORIZED", "Unauthorized", req.originalUrl, {});
+            e.statusCode = 401;
+            throw e;
+        }
+
+        // 서비스 호출
+        const home = await upsertHomeMyPlace(userId, req.body);
+
+        // 응답
+        return res.status(200).json(
+            new CustomSuccess(
+                "HOME-200-001",
+                200,
+                "홈 설정 성공",
+                home
+            )
+        );
+    } catch (err) {
+        return next(err);
+    }
+};
+
+// 홈 삭제
+export const removeHomeHandler = async (req, res, next) => {
+    try {
+        const userId = req.user.userId;
+        if (!userId) {
+            const e = new CustomError("UNAUTHORIZED", "Unauthorized", req.originalUrl, {});
+            e.statusCode = 401;
+            throw e;
+        }
+        
+        // 서비스 호출
+        await deleteHomeMyPlace(userId);
+
+        // 응답
+        return res.status(200).json(
+            new CustomSuccess(
+                "HOME-200-002",
+                200,
+                "홈 삭제 성공",
+                {}
+            )
+        );
+
+    } catch (err) {
+        return next(err);
+    }
+}

--- a/src/repositories/place.repository.js
+++ b/src/repositories/place.repository.js
@@ -73,3 +73,36 @@ export const deletePlace = async ({ myplace_id, user_id }) => {
     },
   });
 };
+
+// HOME: 기존 홈 1개 조회(업서트)
+export const findHomeByUserId = async ({ user_id }) => {
+  return prisma.myPlace.findFirst({
+    where: {
+      user_id: BigInt(user_id),
+      place_type: "HOME",
+    },
+    orderBy: { updated_at: "desc" }, // 최신 1개
+    select: {
+      myplace_id: true,
+      user_id: true,
+      place_type: true,
+      provider_place_id: true,
+      place_address: true,
+      place_detail_address: true,
+      latitude: true,
+      longitude: true,
+      created_at: true,
+      updated_at: true,
+    },
+  });
+};
+
+// HOME: 홈 삭제(유저 기준 전부 삭제)
+export const deleteHomeByUserId = async ({ user_id }) => {
+  return prisma.myPlace.deleteMany({
+    where: {
+      user_id: BigInt(user_id),
+      place_type: "HOME",
+    },
+  });
+};

--- a/src/routes/home.route.js
+++ b/src/routes/home.route.js
@@ -1,0 +1,22 @@
+import { Router } from "express";
+import { isLoggedIn } from "../middleware/auth.middleware.js";
+import {
+  upsertHomeHandler,
+  removeHomeHandler,
+} from "../controllers/home.controller.js";
+
+const router = Router();
+
+router.put(
+    "/",
+    isLoggedIn,
+    upsertHomeHandler
+)
+
+router.delete(
+    "/",
+    isLoggedIn,
+    removeHomeHandler
+)
+
+export default router;

--- a/src/services/home.service.js
+++ b/src/services/home.service.js
@@ -1,0 +1,112 @@
+// src/services/home.service.js
+
+import { Prisma } from "@prisma/client";
+import { CustomError } from "../response/customError.js";
+import {
+  insertPlace,
+  patchPlace,
+  findHomeByUserId,
+  deleteHomeByUserId,
+} from "../repositories/place.repository.js";
+
+// HOME upsert (홈 설정/변경)
+export const upsertHomeMyPlace = async (user_id, data) => {
+    if (!user_id) {
+        const e = new CustomError("AUTH-401-000", "Unauthorized", "/myplaces/home", {});
+        e.statusCode = 401;
+        throw e;
+    }
+
+    // 최소 필수값 검증
+    const required = ["provider_place_id", "place_address", "latitude", "longitude"];
+    for (const key of required) {
+        if (data?.[key] === undefined || data?.[key] === null || data?.[key] === "") {
+            const e = new CustomError(
+                "HOME-400-001",
+                "Invalid request body",
+                "/myplaces/home",
+                { field: key }
+            );
+            e.statusCode = 400;
+            throw e;
+        }
+    }
+
+    // 기존 HOME(최신 1개) 조회
+    const existing = await findHomeByUserId({ user_id });
+    
+    // 기존 HOME 있으면 update
+    if (existing?.myplace_id) {
+        const result  = await patchPlace({
+            myplace_id: existing.myplace_id,
+            user_id,
+            data: {
+                place_type: "HOME", // 서버에서 고정
+                provider_place_id: data.provider_place_id,
+                place_address: data.place_address,
+                place_detail_address: data.place_detail_address ?? null,
+                latitude: data.latitude,
+                longitude: data.longitude,
+            },
+        });
+
+        if (!result || result.count === 0) {
+            const e = new CustomError("HOME-404-001", "Home not found", "/myplaces/home", {});
+            e.statusCode = 404;
+            throw e;
+        }
+
+        // 업데이트된 row 반환
+        return {
+            myplace_id: String(existing.myplace_id),
+            user_id: String(user_id),
+            place_type: "HOME",
+            provider_place_id: data.provider_place_id,
+            place_address: data.place_address,
+            place_detail_address: data.place_detail_address ?? null,
+            latitude: data.latitude,
+            longitude: data.longitude,
+        };
+    }
+
+    // 기존 HOME 없으면 create
+    try {
+        const created = await insertPlace({
+            user_id,
+            place_type: "HOME",
+            provider_place_id: data.provider_place_id,
+            place_address: data.place_address,
+            place_detail_address: data.place_detail_address ?? null,
+            latitude: data.latitude,
+            longitude: data.longitude,
+        });
+
+        return created;
+    } catch (err) {
+        if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+            const e = new CustomError(
+                "HOME-409-001",
+                "Home place already exists",
+                "/myplaces/home",
+                { fields: ["user_id", "place_type", "provider_place_id"] }
+            );
+            e.statusCode = 409;
+            throw e;
+        }
+        throw err;
+    }
+}
+
+// HOME delete (홈 삭제)
+export const deleteHomeMyPlace = async (user_id) => {
+    if (!user_id) {
+        const e = new CustomError("AUTH-401-000", "Unauthorized", "/myplaces/home", {});
+        e.statusCode = 401;
+        throw e;
+    }
+
+    // user_id 기준으로 삭제(멱등)
+    await deleteHomeByUserId({ user_id });
+
+    return {};
+};


### PR DESCRIPTION
## 구현 사항
- 홈(MyPlace) 설정/변경(UPSERT, PUT) / 삭제(DELETE) API 구현
- `place_type` = HOME 고정, 컨트롤러에서 타입 주입
- 홈은 유저당 1개 정책 서비스 로직으로 보장
- 컨트롤러/라우터/서비스 분리, 레포지토리는 자주가는장소와 공용 레이어 유지

## 구현 상세
**설정/변경(UPSERT, PUT)**
- 기존 HOME 존재 여부 조회 후 분기
  - 존재: updateMany로 기존 HOME 갱신
  - 미존재: create로 HOME 생성
- 요청 바디 필수값 검증(누락/빈값 차단)
  - `provider_place_id`, `place_address`, `latitude`, `longitude`
- 요청 바디 정규화
  - `place_detail_address` 미전달 시 null 처리
- HOME은 조회 기준 최신 1개만 사용(중복 데이터가 있어도 동작 안정)

**삭제(DELETE)**
- 유저 기준 HOME 전체 삭제(deleteMany)
- 멱등 처리: HOME이 없어도 성공 응답
  - (중복 HOME 데이터가 존재해도 삭제 시 함께 정리됨)

## 보안/정책
- HOME은 path/query 없이 토큰의 userId 기준으로만 처리
- place_type 수정 불가(HOME 고정)
- 인증 실패 시 401 반환
- 라우터 마운트 우선순위 조정으로 /api/myplaces/home 경로 충돌 방지

## 테스트
- HOME 없음 상태에서 PUT → 생성 성공 확인
- PUT 재호출 시 기존 HOME 갱신(정상 응답) 확인
- DELETE 호출 시 삭제 성공 확인
- DELETE 재호출 시 멱등 성공 응답 확인
- 라우터 충돌(PLACE 라우터로 라우팅) 재현 후 수정 적용으로 해결 확인

Related to #36 