### PR TITLE
✨  feature/#4 : CI/CD: GitHub Actions 기반 EC2 자동 배포 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy Makcha Backend
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy to EC2
+        run: |
+          ssh ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+            cd ~/makcha-backend
+            git pull origin develop
+            docker-compose down
+            docker-compose up -d --build
+          EOF


### PR DESCRIPTION
## 🚀 변경 사항 요약
GitHub Actions를 활용한 Backend 서버 자동 배포(CI/CD) 파이프라인을 추가했습니다.

- develop 브랜치에 push 시
- EC2 서버에 SSH 접속
- 최신 코드 pull
- docker-compose 기반 컨테이너 재빌드 및 재기동


---

## 🛠️ 주요 변경 내용
- `.github/workflows/deploy.yml` 추가
  - GitHub Actions 워크플로우 정의
  - EC2 SSH 접속 후 자동 배포 수행
- 민감 정보는 GitHub Secrets로 관리
  - `EC2_HOST`
  - `EC2_USER`
  - `EC2_SSH_KEY`

---

## 🔐 보안 관련
- SSH Private Key 및 `.env` 파일은 `.gitignore`로 제외
- GitHub Secrets를 통해 안전하게 관리

---

## ✅ 테스트 방법
1. 해당 PR을 `develop` 브랜치로 merge
2. GitHub Actions 탭에서 `Deploy Makcha Backend` 워크플로우 실행 여부 확인
3. EC2 서버에서 컨테이너 정상 기동 여부 확인

---

## 📌 참고 사항
- 현재 Notification 관련 라우트는 서버 안정화를 위해 비활성화된 상태입니다.
- HTTPS 및 도메인 연결(Nginx, Certbot)은 후속 작업으로 진행 예정입니다.
