### PR TITLE
🐛 feature/#52 : http에서 실행 시 문제 보완

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -2,11 +2,13 @@ import authService from '../services/auth.service.js';
 import { CustomSuccess } from '../response/customSuccess.js';
 import { CustomError } from '../response/customError.js'; //공통 응답 구조 사용함.
 
+const isProd = process.env.NODE_ENV === 'production'; //http 상태(웹 미배포)에서도 쿠키를 브라우저에서 받을 수 있도록 함.
 
 //POST /auth/kakao 카카오 로그인 컨트롤러
 const kakaoLogin = async (req, res, next) => {
     try {
-      const { code } = req.body;
+      // const { code } = req.body;
+      const { code, redirectUri } = req.body;  // redirectUri를 파라미터를 받을 수 있도록 추가
   
       if (!code) {
         throw new CustomError(
@@ -15,14 +17,17 @@ const kakaoLogin = async (req, res, next) => {
           req.originalUrl
         );
       }
-  
-      const result = await authService.kakaoLogin(code);
+      
+      // redirectUri를 service로 전달
+      const result = await authService.kakaoLogin(code, redirectUri);
   
       // Refresh Token 쿠키 저장
       res.cookie('refreshToken', result.refreshToken, {
         httpOnly: true,
-        secure: true,
-        sameSite: 'none',
+        secure: isProd, 
+        // secure: true,
+        sameSite: isProd ? 'none' : 'lax', 
+        // sameSite: 'none',
       });
   
       const response = new CustomSuccess(
@@ -55,8 +60,10 @@ const kakaoLogin = async (req, res, next) => {
   
       res.cookie('refreshToken', result.refreshToken, {
         httpOnly: true,
-        secure: true,
-        sameSite: 'none',
+        secure: isProd,
+        // secure: true,
+        sameSite: isProd ? 'none' : 'lax', 
+        //sameSite: 'none',
       });
   
       const response = new CustomSuccess(
@@ -82,8 +89,8 @@ const logout = async (req, res, next) => {
     // refreshToken 쿠키 삭제
     res.clearCookie('refreshToken', {
       httpOnly: true,
-      secure: true,
-      sameSite: 'none',
+      secure: isProd,
+      sameSite: isProd ? 'none' : 'lax',
     });
 
     const response = new CustomSuccess(
@@ -108,8 +115,8 @@ const withdraw = async (req, res, next) => {
     // refreshToken 쿠키 삭제
     res.clearCookie('refreshToken', {
       httpOnly: true,
-      secure: true,
-      sameSite: 'none',
+      secure: isProd,
+      sameSite: isProd ? 'none' : 'lax',
     });
 
     const response = new CustomSuccess(
@@ -123,7 +130,21 @@ const withdraw = async (req, res, next) => {
     next(err);
   }
 };
-  
-  
-  export default { kakaoLogin, refresh, logout, withdraw };
+
+// 백엔드 테스트 용도. -> 프론트 사용 X
+const kakaoTestCallback = (req, res) => {
+  const { code, error } = req.query;
+
+  if (error) {
+    return res.send(`<h2>❌ Kakao Error</h2><p>${error}</p>`);
+  }
+
+  return res.send(`
+    <h2> Kakao Auth Test Success</h2>
+    <p><b>code:</b> ${code}</p>
+    <p>이 code를 Postman에 넣어주세요.</p>
+  `);
+};
+
+export default { kakaoLogin, refresh, logout, withdraw,kakaoTestCallback };
 

--- a/src/routes/auth.route.js
+++ b/src/routes/auth.route.js
@@ -205,6 +205,10 @@ router.post('/phone/send', isLoggedIn, phoneController.send);
  */
 router.post('/phone/verify', isLoggedIn, phoneController.verify);
 
-
+//백엔드 테스트용 -> 프론트 사용X.
+router.get(
+    '/auth/kakao/test-callback',
+    authController.kakaoTestCallback
+  );
 
 export default router;

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -6,16 +6,21 @@ import { CustomError } from '../response/customError.js';
 /**
  * 카카오 로그인 서비스
  * @param {string} code - 카카오 인가 코드
+ * @param {string} redirectUri - 프론트에서 인가코드 받을 때 사용한 redirect URI (선택)
  */
-const kakaoLogin = async (code) => {
+const kakaoLogin = async (code, redirectUri ) => { // redirectUri 파라미터 추가
   try {
+
+    // redirectUri가 없으면 .env 기본값 사용
+    const finalRedirectUri = redirectUri || process.env.KAKAO_REDIRECT_URI;
+    
     // 카카오 Access Token 발급 진행.
     const tokenRes = await axios.post(
       'https://kauth.kakao.com/oauth/token',
       new URLSearchParams({
         grant_type: 'authorization_code',
         client_id: process.env.KAKAO_CLIENT_ID,
-        redirect_uri: process.env.KAKAO_REDIRECT_URI,
+        redirect_uri: finalRedirectUri, //동적으로 처리하도록 함.
         code,
       }),
       { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
@@ -169,5 +174,7 @@ const withdraw = async (user) => {
     );
   }
 };
+
+
 
 export default { kakaoLogin, refresh, logout, withdraw };

--- a/src/services/notification.service.js
+++ b/src/services/notification.service.js
@@ -107,10 +107,12 @@ export const updateSettings = async (user_id, timeList) => {
 
 export const checkAndSendNotifications = async () => {
     const currentTime = new Date();
+    let notifications; //try 밖에서 선언함.(try 밖에서 변수 선언 -> try 안에서 값을 할당하도록)
 
     try {
         // 1. 아직 발송 완료되지 않은(sent_success: false) 알림들 조회
-        const notifications = await notiRepo.findPendingNotifications(currentTime);
+        notifications = await notiRepo.findPendingNotifications(currentTime);
+        // const notifications = await notiRepo.findPendingNotifications(currentTime);
     } catch (error) {
         throw new CustomError(
             "COM-500-001",


### PR DESCRIPTION
## 📱 전화번호 SMS 인증 기능 구현

- 프론트엔드에서 ngrok 등 다양한 환경에서 카카오 로그인 테스트 시 발생하던 500 에러 해결
---

## 🛠️ 주요 변경 사항

###  redirectUri 동적 처리
- POST /auth/kakao 요청 시 redirectUri 파라미터 추가
- 카카오 토큰 교환 시 프론트에서 전달받은 redirectUri 사용
- 파라미터 미전달 시 .env의 KAKAO_REDIRECT_URI 기본값 사용

###  쿠키 설정 환경별 분리
- 개발환경(http): secure: false, sameSite: 'lax'
- 운영환경(https): secure: true, sameSite: 'none'

---


## 📌 참고 사항
- x.
