### PR TITLE
Fix/#65 API 경로 수정 (/api/facility -> /api/facilities)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -40,7 +40,7 @@ app.use("/api", recentDestinationRouter);
 app.use("/api", placeRouter);
 app.use("/api/save-reports", saveReportRouter);
 app.use("/api/me", myinfoRouter);
-app.use("/api/facility", facilityRouter);  
+app.use("/api/facilities", facilityRouter);  
 app.use("/api/route", routeRouter);   
 app.use("/api/routes", routeCandidateRouter);
 

--- a/src/controllers/facility.controller.js
+++ b/src/controllers/facility.controller.js
@@ -63,16 +63,8 @@ class FacilityController {
         keyword: keyword || ''
       };
 
-      // TODO: 실제 서비스 로직 연결 필요
-      // const result = await this.service.searchFacilities(searchParams);
-      
-      // 임시 응답 (서비스 구현 전까지)
-      const result = {
-        facilities: [],
-        total: 0,
-        searchParams: searchParams,
-        message: '시설 검색 기능 구현 예정'
-      };
+      // 실제 서비스 로직 호출
+      const result = await this.service.searchFacilities(searchParams);
 
       const response = new CustomSuccess(
         'FAC-200-001',
@@ -144,17 +136,8 @@ class FacilityController {
         radius: radius ? parseInt(radius) : 1000
       };
 
-      // TODO: 실제 서비스 로직 연결 필요
-      // const result = await this.service.searchByCategory(searchParams);
-      
-      // 임시 응답 (서비스 구현 전까지)
-      const result = {
-        category: categoryType,
-        facilities: [],
-        total: 0,
-        searchParams: searchParams,
-        message: '카테고리별 시설 검색 기능 구현 예정'
-      };
+      // 실제 서비스 로직 호출
+      const result = await this.service.searchByCategory(searchParams);
 
       const response = new CustomSuccess(
         'FAC-200-002',

--- a/src/routes/facility.route.js
+++ b/src/routes/facility.route.js
@@ -1,10 +1,18 @@
 import { Router } from 'express';
 import FacilityController from '../controllers/facility.controller.js';
+import FacilityService from '../services/facility.service.js';
+import KakaoMapClient from '../clients/kakaoMap.client.js';   // 정확한 파일명으로 수정
+import { DistanceUtil } from '../utils/distance.util.js';
 
 const router = Router();
 
-// 컨트롤러 인스턴스 생성 (서비스는 null로 전달 - TODO에서 구현 예정이므로)
-const facilityController = new FacilityController(null);
+// 의존성 주입: KakaoMapClient, DistanceUtil 생성 후 FacilityService에 전달
+const kakaoClient = new KakaoMapClient();
+const distanceUtil = new DistanceUtil();
+const facilityService = new FacilityService(kakaoClient, distanceUtil);
+
+// 컨트롤러 인스턴스 생성 (FacilityService 주입)
+const facilityController = new FacilityController(facilityService);
 
 /**
  * @swagger

--- a/src/routes/facility.route.js
+++ b/src/routes/facility.route.js
@@ -3,7 +3,7 @@ import FacilityController from '../controllers/facility.controller.js';
 
 const router = Router();
 
-// 👇 컨트롤러 인스턴스 생성 (서비스는 null로 전달 - TODO에서 구현 예정이므로)
+// 컨트롤러 인스턴스 생성 (서비스는 null로 전달 - TODO에서 구현 예정이므로)
 const facilityController = new FacilityController(null);
 
 /**


### PR DESCRIPTION
## 버그 수정 및 기능 구현

### 문제 상황
1. **404 에러 발생**
   - 프론트엔드에서 `/api/facilities/search` 호출 시 404 에러
   - 스웨거 문서: `/facilities/search` (복수형)
   - 실제 코드: `/api/facility/search` (단수형)
   - 경로 불일치로 인한 에러

2. **빈 데이터 응답**
   - `facilities: []` 빈 배열 반환
   - 실제 카카오맵 API 미연동

### 수정 내용

**1. API 경로 수정 (app.js)**
```javascript
// 수정 전
app.use("/api/facility", facilityRouter);

// 수정 후
app.use("/api/facilities", facilityRouter);
```

**2. 실제 서비스 로직 연동**

*facility.controller.js*
- TODO 주석 제거
- 실제 FacilityService 호출 로직 적용
- `searchFacilities()` 메서드 완성
- `searchByCategory()` 메서드 완성

*facility.route.js*
- FacilityService 의존성 주입 추가
- KakaoMapClient, DistanceUtil 인스턴스 생성
- Controller에 Service 전달

### API 응답 예시
```json
{
  "successCode": "FAC-200-001",
  "statusCode": 200,
  "message": "주변 시설 검색 성공",
  "result": {
    "facilities": [
      {
        "id": "13495983",
        "name": "카페 그레이스",
        "category": "CAFE",
        "lat": 37.567085,
        "lng": 126.976501,
        "address": "서울 종구 대청도1가 60-10",
        "distance": 147.22
      }
    ],
    "totalCount": 15
  }
}
```

### 테스트
- [x] 서버 정상 실행 확인
- [x] `/api/facilities/search` 200 응답 확인
- [x] 실제 카카오맵 API 데이터 반환 확인
- [x] API 엔드포인트 정상 작동 확인

### 관련 이슈
#66 프론트엔드 연동 시 404 에러 및 데이터 요청 대응