### PR TITLE
feature: polyline 응답에 map_type 추가

### DIFF
--- a/src/swagger/swagger.js
+++ b/src/swagger/swagger.js
@@ -600,6 +600,11 @@ const options = {
               description: "ODsay 노선 타입 코드",
               example: 6,
             },
+            map_type: {
+              type: "string",
+              description: "버스/지하철 노선 색상 코드",
+              example: "SUBWAY_6",
+            },
             points: {
               type: "array",
               items: { $ref: "#/components/schemas/RouteCandidatePoint" },

--- a/src/utils/odsayPolyline.util.js
+++ b/src/utils/odsayPolyline.util.js
@@ -3,6 +3,22 @@ function asNumber(v) {
   return Number.isFinite(n) ? n : null;
 }
 
+// ODsay 버스 타입 -> mapType(색) 매핑 (candidates와 동일)
+function busTypeToMapType(t) {
+  if (t === 4 || t === 6 || t === 14 || t === 15) return "BUS_RED";
+  if (t === 11) return "BUS_BLUE";
+  if (t === 5) return "BUS_SKY";
+  if (t === 13) return "BUS_ORANGE";
+  if (t === 1 || t === 2 || t === 3 || t === 12) return "BUS_GREEN";
+  return "BUS";
+}
+
+function laneToMapType({ cls, type }) {
+  if (cls === 2 && Number.isFinite(type)) return `SUBWAY_${type}`;
+  if (cls === 1 && Number.isFinite(type)) return busTypeToMapType(type);
+  return "UNKNOWN";
+}
+
 export function parseLoadLaneToPaths(data) {
   const result = data?.result;
   const laneArr = Array.isArray(result?.lane) ? result.lane : [];
@@ -23,6 +39,10 @@ export function parseLoadLaneToPaths(data) {
     return {
       class: asNumber(lane?.class), // 1(버스), 2(지하철)
       type: asNumber(lane?.type), // 노선 타입
+      map_type: laneToMapType({
+        cls: asNumber(lane?.class),
+        type: asNumber(lane?.type),
+      }),
       points,
     };
   });


### PR DESCRIPTION
폴리라인 조회 API 응답의 각 구간(paths)에
candidates와 동일한 교통수단 타입(map_type)을 추가했습니다. (스타일 매핑용)

- BUS_GREEN / BUS_RED / BUS_BLUE 등
- SUBWAY_{lineCode}