### PR TITLE
feature/#53 : 전화번호 인증 저장소 Map에서 Redis 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.4.7",
         "express": "^5.0.1",
         "express-rate-limit": "^8.2.1",
+        "ioredis": "^5.9.2",
         "jsonwebtoken": "^9.0.3",
         "mysql2": "^3.16.0",
         "node-cron": "^3.0.3",
@@ -73,6 +74,12 @@
       "peerDependencies": {
         "openapi-types": ">=7"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
+      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
+      "license": "MIT"
     },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
@@ -464,6 +471,15 @@
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/combined-stream": {
@@ -1196,6 +1212,30 @@
       "version": "2.0.4",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz",
+      "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
@@ -1337,6 +1377,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -1348,6 +1394,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -1725,7 +1777,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"
@@ -1834,6 +1885,27 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/router": {
@@ -2040,6 +2112,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dotenv": "^16.4.7",
     "express": "^5.0.1",
     "express-rate-limit": "^8.2.1",
+    "ioredis": "^5.9.2",
     "jsonwebtoken": "^9.0.3",
     "mysql2": "^3.16.0",
     "node-cron": "^3.0.3",

--- a/src/config/redis.js
+++ b/src/config/redis.js
@@ -1,0 +1,22 @@
+import Redis from 'ioredis';
+
+const redis = new Redis({
+  host: process.env.REDIS_HOST || 'localhost',
+  port: process.env.REDIS_PORT || 6379,
+});
+
+redis.on('connect', () => {
+  console.log('Redis 연결 성공');
+});
+
+redis.on('error', (err) => {
+  console.error('Redis 연결 에러:', err);
+});
+
+export default redis;
+```
+
+**3. `.env` 파일에 Redis 설정 추가:**
+```
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/src/services/phone.service.js
+++ b/src/services/phone.service.js
@@ -13,7 +13,7 @@ const sendVerificationCode = async (phoneNumber) => {
     const code = Math.floor(100000 + Math.random() * 900000).toString();
   
     try {
-      saveCode(phoneNumber, code);
+      await saveCode(phoneNumber, code);
     } catch (err) {
       if (err.message === 'AUTH-429-001') {
         throw new CustomError(
@@ -30,7 +30,7 @@ const sendVerificationCode = async (phoneNumber) => {
 
 // 인증번호 확인 및 전화번호 저장.
 const verifyCodeAndSavePhone = async ({ userId, phoneNumber, code }) => {
-  const isValid = verifyCode(phoneNumber, code);
+  const isValid = await verifyCode(phoneNumber, code);
 
   if (!isValid) {
     throw new CustomError(
@@ -49,7 +49,7 @@ const verifyCodeAndSavePhone = async ({ userId, phoneNumber, code }) => {
   });
 
   // 인증 완료 후 코드 제거
-  deleteCode(phoneNumber);
+  await deleteCode(phoneNumber);
 };
 
 export default {

--- a/src/utils/phoneVerification.utils.js
+++ b/src/utils/phoneVerification.utils.js
@@ -1,8 +1,10 @@
 // utils/phoneVerification.utils.js
 
-const store = new Map();
+// const store = new Map();
+import redis from '../config/redis.js'; // redis로 바꿈
+//서버 재시작해도 데이터 유지됨. 여러 서버 인스턴스 공유 가능함.
 
-const TTL = 3 * 60 * 1000;      // 3분
+const TTL = 3 * 60;      // 3분
 const MAX_SEND_COUNT = 3;       // 3분 동안 최대 3회
 
 /**
@@ -13,48 +15,50 @@ const MAX_SEND_COUNT = 3;       // 3분 동안 최대 3회
  *   count,
  *   firstSentAt
  * }
- */ //무한 요청을 방지했습니다.(금액 보완)
+ */ //무한 요청을 방지했습니다.(금액 보완) 
 
-export const saveCode = (phoneNumber, code) => {
+export const saveCode = async (phoneNumber, code) => {
+  const key = `phone:${phoneNumber}`;
   const now = Date.now();
-  const existing = store.get(phoneNumber);
-
-  // 이미 기록이 있고, 아직 3분이 지나지 않았다면
-  if (existing && now < existing.expiresAt) {
-    if (existing.count >= MAX_SEND_COUNT) {
-      // 서비스에서 CustomError로 변환해서 처리
+  
+  const existing = await redis.get(key);
+  
+  if (existing) {
+    const data = JSON.parse(existing);
+    
+    // 아직 TTL 내라면
+    if (data.count >= MAX_SEND_COUNT) {
       throw new Error('AUTH-429-001');
     }
-
-    // 횟수만 증가 + 코드 갱신 (expiresAt은 유지)
-    store.set(phoneNumber, {
-      ...existing,
+    
+    // 횟수 증가 + 코드 갱신 (TTL 유지를 위해 KEEPTTL 사용)
+    await redis.set(key, JSON.stringify({
+      ...data,
       code,
-      count: existing.count + 1,
-    });
+      count: data.count + 1,
+    }), 'KEEPTTL');
     return;
   }
-
-  // 처음 요청이거나, 3분이 지난 경우 → 새 세션 시작
-  store.set(phoneNumber, {
+  
+  // 새 세션 시작
+  await redis.set(key, JSON.stringify({
     code,
-    expiresAt: now + TTL,
     count: 1,
     firstSentAt: now,
-  });
+  }), 'EX', TTL);
 };
 
-export const verifyCode = (phoneNumber, code) => {
-    const data = store.get(phoneNumber);
-    if (!data) return false;
+export const verifyCode = async (phoneNumber, code) => {
+  const key = `phone:${phoneNumber}`;
+  const data = await redis.get(key);
   
-    if (Date.now() > data.expiresAt) {
-      store.delete(phoneNumber); // 만료 시 제거할 수 있도록 함.
-      return false;
-    }
+  if (!data) return false;
   
-    return data.code === code;
-  };
-export const deleteCode = (phoneNumber) => {
-  store.delete(phoneNumber);
+  const parsed = JSON.parse(data);
+  return parsed.code === code;
+};
+
+export const deleteCode = async (phoneNumber) => {
+  const key = `phone:${phoneNumber}`;
+  await redis.del(key);
 };


### PR DESCRIPTION
## 📱 전화번호 SMS 인증 기능 Map -> Redis로 변경


## 🛠️ 주요 변경 사항

### 새로 추가한 파일
- src/config/redis.js` - Redis 연결 설정

###수정된 파일
-  src/utils/phoneVerification.utils.js - Map → Redis 저장소 변경
-  src/services/phone.service.js - async/await 적용
-  package.json - ioredis 패키지 추가

### 개선 효과
- 서버 재시작 시에도 인증번호 데이터 유지
- 다중 서버 인스턴스 환경에서 세션 공유 가능
- TTL 자동 만료 기능 활용 (3분)


---


## 📌 참고 사항
- https://inpa.tistory.com/entry/REDIS-NODE-%F0%9F%93%9A-%EB%85%B8%EB%93%9Cexpress%EC%97%90%EC%84%9C-redis-%EC%82%AC%EC%9A%A9%EB%B2%95-%EC%BA%90%EC%8B%B1-%EC%84%B8%EC%85%98-%EC%8A%A4%ED%86%A0%EC%96%B4 참고했습니다.
- 기존 Map 로직과 동일하게 동작
- 배포 서버 .env에 레디스 환경 설정 이미 추가했습니다.