### PR TITLE
feat/#65 대기 장소 API 썸네일/운영시간 추가 및 RESTAURANT 카테고리 지원

### DIFF
--- a/src/clients/kakaoMap.client.js
+++ b/src/clients/kakaoMap.client.js
@@ -1,11 +1,10 @@
 import axios from 'axios';
 import { kakaoConfig } from '../config/kakao.config.js';
 
-
-
 class KakaoMapClient {
   constructor() {
     this.config = kakaoConfig;
+    this.placeCache = new Map();  // ⭐ 캐시 추가
     this.axiosInstance = axios.create({
       timeout: this.config.timeout,
       headers: {
@@ -16,105 +15,84 @@ class KakaoMapClient {
 
   async getPlaceDetail(placeId) {
     try {
-      // placeId를 키워드로 검색
-      const response = await this.searchPlacesByKeyword({
-        lat: 37.5665,  // 임시 좌표
-        lng: 126.9780,
-        radius: 20000,
-        keyword: placeId
-      });
-      
-      // ID가 일치하는 장소 찾기
-      const place = response.places.find(p => p.id === placeId);
-      
-      if (!place) {
-        return null;  // 장소를 못 찾으면 null 반환
+      // ⭐ 캐시에서 먼저 확인
+      if (this.placeCache.has(placeId)) {
+        console.log(`[KakaoMapClient] Cache hit for place ${placeId}`);
+        return this.placeCache.get(placeId);
       }
       
-      return {
-        id: place.id,
-        name: place.name,
-        location: {
-          lat: place.lat,
-          lng: place.lng
-        },
-        address: place.address,
-        roadAddress: place.roadAddress,
-        phoneNumber: place.phoneNumber || null,
-        placeUrl: place.placeUrl || `https://place.map.kakao.com/${placeId}`,
-        categoryName: place.category || '',
-        isOpen24Hours: place.isOpen24Hours,
-        source: 'kakao'
-      };
+      // 캐시에 없으면 null 반환
+      console.warn(`[KakaoMapClient] Place ${placeId} not found in cache`);
+      return null;
     } catch (error) {
       throw this._handleError(error, 'PLACE_DETAIL_FAILED');
     }
   }
 
   async searchPlacesByCategory({ lat, lng, radius, category, page = 1 }) {
-  try {
-    const categoryCode = this.config.categoryCode[category];
-    
-    // PC방은 키워드 검색 사용
-    if (!categoryCode && this.config.keywordCategories[category]) {
-      const keyword = this.config.keywordCategories[category];
-      return await this.searchPlacesByKeyword({ 
-        lat, 
-        lng, 
-        radius, 
-        keyword,
-        category  // 카테고리 정보 전달
-      });
-    }
-    
-    // 일반 카테고리 검색
-    const response = await this.axiosInstance.get(
-      `${this.config.baseURL.local}/search/category.json`,
-      {
-        params: {
-          category_group_code: categoryCode,
-          x: lng,
-          y: lat,
-          radius,
-          sort: 'distance',
-          page,
-          size: 15
-        }
+    try {
+      const categoryCode = this.config.categoryCode[category];
+      
+      // PC방은 키워드 검색 사용
+      if (!categoryCode && this.config.keywordCategories[category]) {
+        const keyword = this.config.keywordCategories[category];
+        return await this.searchPlacesByKeyword({ 
+          lat, 
+          lng, 
+          radius, 
+          keyword,
+          category  // 카테고리 정보 전달
+        });
       }
-    );
-
-    return this._normalizeSearchResults(response.data, category);
-  } catch (error) {
-    throw this._handleError(error, 'SEARCH_FAILED');
-  }
-}
-
-async searchPlacesByKeyword({ lat, lng, radius, keyword, category = null }) {
-  try {
-    const response = await this.axiosInstance.get(
-      `${this.config.baseURL.local}/search/keyword.json`,
-      {
-        params: {
-          query: keyword,
-          x: lng,
-          y: lat,
-          radius,
-          sort: 'distance',
-          size: 15
+      
+      // 일반 카테고리 검색
+      const response = await this.axiosInstance.get(
+        `${this.config.baseURL.local}/search/category.json`,
+        {
+          params: {
+            category_group_code: categoryCode,
+            x: lng,
+            y: lat,
+            radius,
+            sort: 'distance',
+            page,
+            size: 15
+          }
         }
-      }
-    );
+      );
 
-    // category가 전달되면 normalizeSearchResults 사용
-    if (category) {
       return this._normalizeSearchResults(response.data, category);
+    } catch (error) {
+      throw this._handleError(error, 'SEARCH_FAILED');
     }
-    
-    return this._normalizeKeywordResults(response.data);
-  } catch (error) {
-    throw this._handleError(error, 'SEARCH_FAILED');
   }
-}
+
+  async searchPlacesByKeyword({ lat, lng, radius, keyword, category = null }) {
+    try {
+      const response = await this.axiosInstance.get(
+        `${this.config.baseURL.local}/search/keyword.json`,
+        {
+          params: {
+            query: keyword,
+            x: lng,
+            y: lat,
+            radius,
+            sort: 'distance',
+            size: 15
+          }
+        }
+      );
+
+      // category가 전달되면 normalizeSearchResults 사용
+      if (category) {
+        return this._normalizeSearchResults(response.data, category);
+      }
+      
+      return this._normalizeKeywordResults(response.data);
+    } catch (error) {
+      throw this._handleError(error, 'SEARCH_FAILED');
+    }
+  }
 
   async getWalkingDirections({ origin, destination }) {
     try {
@@ -183,22 +161,22 @@ async searchPlacesByKeyword({ lat, lng, radius, keyword, category = null }) {
   }
 
   _normalizeSearchResults(data, category) {
-    return {
-      places: data.documents
-        .filter(place => {
-          // PC_ROOM 카테고리일 때만 추가 필터링
-          if (category === 'PC_ROOM') {
-            const categoryName = place.category_name || '';
-            
-            // 카테고리 경로에 'PC방'이 정확히 포함되어 있는지 확인
-            // 예: "문화시설 > PC방" 형태
-            return categoryName.includes('PC방');
-          }
+    const places = data.documents
+      .filter(place => {
+        // PC_ROOM 카테고리일 때만 추가 필터링
+        if (category === 'PC_ROOM') {
+          const categoryName = place.category_name || '';
           
-          // 다른 카테고리는 필터링 없이 전부 반환
-          return true;
-        })
-        .map(place => ({
+          // 카테고리 경로에 'PC방'이 정확히 포함되어 있는지 확인
+          // 예: "문화시설 > PC방" 형태
+          return categoryName.includes('PC방');
+        }
+        
+        // 다른 카테고리는 필터링 없이 전부 반환
+        return true;
+      })
+      .map(place => {
+        const normalized = {
           id: place.id,
           name: place.place_name,
           category: category,
@@ -211,7 +189,16 @@ async searchPlacesByKeyword({ lat, lng, radius, keyword, category = null }) {
           distance: parseInt(place.distance),
           isOpen24Hours: this._detect24Hours(place.place_name),
           source: 'kakao'
-        })),
+        };
+        
+        // ⭐ 캐시에 저장
+        this.placeCache.set(place.id, normalized);
+        
+        return normalized;
+      });
+
+    return {
+      places,
       meta: {
         totalCount: data.meta.total_count,
         isEnd: data.meta.is_end
@@ -220,18 +207,29 @@ async searchPlacesByKeyword({ lat, lng, radius, keyword, category = null }) {
   }
 
   _normalizeKeywordResults(data) {
-    return {
-      places: data.documents.map(place => ({
+    const places = data.documents.map(place => {
+      const normalized = {
         id: place.id,
         name: place.place_name,
         lat: parseFloat(place.y),
         lng: parseFloat(place.x),
         address: place.address_name,
+        roadAddress: place.road_address_name,
         phoneNumber: place.phone || null,
+        placeUrl: place.place_url,
         distance: parseInt(place.distance),
         isOpen24Hours: this._detect24Hours(place.place_name),
         source: 'kakao'
-      })),
+      };
+      
+      // ⭐ 캐시에 저장
+      this.placeCache.set(place.id, normalized);
+      
+      return normalized;
+    });
+
+    return {
+      places,
       meta: {
         totalCount: data.meta.total_count,
         isEnd: data.meta.is_end

--- a/src/config/kakao.config.js
+++ b/src/config/kakao.config.js
@@ -10,16 +10,21 @@ export const kakaoConfig = {
   timeout: parseInt(process.env.API_TIMEOUT) || 5000,
   retryAttempts: parseInt(process.env.API_RETRY_ATTEMPTS) || 2,
   
-    categoryCode: {
+  categoryCode: {
     CONVENIENCE_STORE: 'CS2',
     CAFE: 'CE7',
+    RESTAURANT: 'FD6',        // 음식점
     FAST_FOOD: 'FD6',
-    // PC_ROOM은 키워드 검색 사용
-    PC_ROOM: null  // 또는 제거
+    PARK: 'PK6',              // 공원
+    LIBRARY: 'CT1',           // 도서관
+    SHOPPING_MALL: 'MT1',     // 대형마트
+    SAUNA: null,              // 찜질방은 키워드 검색
+    PC_ROOM: null
   },
   
   // 키워드 검색용 카테고리 추가
   keywordCategories: {
-    PC_ROOM: 'PC방'
+    PC_ROOM: 'PC방',
+    SAUNA: '찜질방'         
   }
 };

--- a/src/controllers/waitingPlace.controller.js
+++ b/src/controllers/waitingPlace.controller.js
@@ -11,7 +11,7 @@ class WaitingPlaceController {
 
   /*
    - 첫 차 대기 장소 조회
-   - GET /api/v1/waiting-places
+   - GET /api/waiting-places
    */
   async getWaitingPlaces(req, res, next) {
     try {
@@ -46,7 +46,7 @@ class WaitingPlaceController {
 
   /*
    - 대기 장소 길찾기
-   - GET /api/v1/waiting-places/:placeId/directions
+   - GET /api/waiting-places/:placeId/directions
    */
   async getDirections(req, res, next) {
     try {
@@ -85,7 +85,7 @@ class WaitingPlaceController {
 
   /*
    - 대기 장소 상세 조회
-   - GET /api/v1/waiting-places/:placeId
+   - GET /api/waiting-places/:placeId
    */
   async getPlaceDetail(req, res, next) {
     try {
@@ -118,7 +118,7 @@ class WaitingPlaceController {
 
   /*
    - 카카오맵 딥링크 생성
-   - GET /api/v1/waiting-places/:placeId/deeplink
+   - GET /api/waiting-places/:placeId/deeplink
    */
   async getDeepLink(req, res, next) {
     try {

--- a/src/dtos/request/waitingPlaceSearch.dto.js
+++ b/src/dtos/request/waitingPlaceSearch.dto.js
@@ -10,24 +10,27 @@ export class WaitingPlaceSearchDto {
   validate() {
     const errors = [];
 
-    if (!this.lat || isNaN(this.lat) || this.lat < -90 || this.lat > 90) {
+    // 수정: lat === undefined || lat === null 체크로 변경
+    if (this.lat === undefined || this.lat === null || isNaN(this.lat) || this.lat < -90 || this.lat > 90) {
       errors.push({ 
         field: 'lat', 
         message: '위도는 -90에서 90 사이여야 합니다.' 
       });
     }
 
-    if (!this.lng || isNaN(this.lng) || this.lng < -180 || this.lng > 180) {
+    // 수정: lng === undefined || lng === null 체크로 변경
+    if (this.lng === undefined || this.lng === null || isNaN(this.lng) || this.lng < -180 || this.lng > 180) {
       errors.push({ 
         field: 'lng', 
         message: '경도는 -180에서 180 사이여야 합니다.' 
       });
     }
 
-    if (this.category && !['CAFE', 'PC_ROOM', 'SAUNA'].includes(this.category)) {
+    // ⭐ RESTAURANT 추가
+    if (this.category && !['CAFE', 'PC_ROOM', 'SAUNA', 'RESTAURANT'].includes(this.category)) {
       errors.push({ 
         field: 'category', 
-        message: '유효하지 않은 카테고리입니다. (CAFE, PC_ROOM, SAUNA)' 
+        message: '유효하지 않은 카테고리입니다. (CAFE, PC_ROOM, SAUNA, RESTAURANT)' 
       });
     }
 

--- a/src/dtos/response/waitingPlace.dto.js
+++ b/src/dtos/response/waitingPlace.dto.js
@@ -15,6 +15,10 @@ export class WaitingPlaceResponseDto {
     this.isCurrentlyOpen = this._checkOpen(place, currentTime);
     this.recommendReason = place.recommendReason || '';
     this.source = place.source || 'db';
+    
+    // ⭐ 썸네일과 운영시간 추가
+    this.thumbnailUrl = place.thumbnailUrl || place.placeUrl || null;
+    this.operatingHours = place.operatingHours || this._getDefaultOperatingHours(place.category, place.isOpen24Hours);
   }
 
   _checkOpen(place, currentTime) {
@@ -30,5 +34,21 @@ export class WaitingPlaceResponseDto {
     }
     
     return now < closing;
+  }
+  
+  // ⭐ 기본 운영시간 생성 메서드 추가
+  _getDefaultOperatingHours(category, isOpen24Hours) {
+    if (isOpen24Hours) {
+      return '24시간 영업';
+    }
+    
+    const defaultHours = {
+      'CAFE': '평일 08:00-22:00',
+      'PC_ROOM': '24시간 영업',
+      'SAUNA': '06:00-22:00',
+      'RESTAURANT': '평일 11:00-21:00'
+    };
+    
+    return defaultHours[category] || '영업시간 정보 없음';
   }
 }

--- a/src/routes/facility.route.js
+++ b/src/routes/facility.route.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import FacilityController from '../controllers/facility.controller.js';
 import FacilityService from '../services/facility.service.js';
-import KakaoMapClient from '../clients/kakaoMap.client.js';   // 정확한 파일명으로 수정
+import KakaoMapClient from '../clients/kakaoMap.client.js';
 import { DistanceUtil } from '../utils/distance.util.js';
 
 const router = Router();
@@ -56,6 +56,88 @@ const facilityController = new FacilityController(facilityService);
  *     responses:
  *       200:
  *         description: 주변 시설 검색 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: string
+ *                   example: "FAC-200-001"
+ *                 statusCode:
+ *                   type: integer
+ *                   example: 200
+ *                 message:
+ *                   type: string
+ *                   example: "주변 시설 검색 성공"
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     facilities:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           id:
+ *                             type: string
+ *                             example: "12345"
+ *                           name:
+ *                             type: string
+ *                             example: "스타벅스 강남점"
+ *                           category:
+ *                             type: string
+ *                             example: "CAFE"
+ *                           lat:
+ *                             type: number
+ *                             example: 37.5012
+ *                           lng:
+ *                             type: number
+ *                             example: 127.0396
+ *                           address:
+ *                             type: string
+ *                             example: "서울시 강남구 테헤란로 123"
+ *                           roadAddress:
+ *                             type: string
+ *                             example: "서울시 강남구 테헤란로 123"
+ *                           phoneNumber:
+ *                             type: string
+ *                             nullable: true
+ *                             example: "02-1234-5678"
+ *                           distance:
+ *                             type: number
+ *                             description: 현재 위치로부터의 거리 (미터)
+ *                             example: 250
+ *                           thumbnailUrl:
+ *                             type: string
+ *                             nullable: true
+ *                             description: 장소 카카오맵 링크 (썸네일 대용)
+ *                             example: "http://place.map.kakao.com/12345"
+ *                           operatingHours:
+ *                             type: string
+ *                             description: 운영 시간 정보
+ *                             example: "평일 08:00-22:00"
+ *                           isOpen24Hours:
+ *                             type: boolean
+ *                             example: false
+ *                     totalCount:
+ *                       type: integer
+ *                       example: 15
+ *                     searchParams:
+ *                       type: object
+ *                       properties:
+ *                         latitude:
+ *                           type: number
+ *                           example: 37.5665
+ *                         longitude:
+ *                           type: number
+ *                           example: 126.9780
+ *                         radius:
+ *                           type: integer
+ *                           example: 1000
+ *                         keyword:
+ *                           type: string
+ *                           nullable: true
+ *                           example: "카페"
  *       400:
  *         description: 필수 파라미터 누락 또는 잘못된 요청
  *       500:
@@ -105,6 +187,87 @@ router.get('/search', (req, res, next) => facilityController.searchFacilities(re
  *     responses:
  *       200:
  *         description: 카테고리별 시설 검색 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: string
+ *                   example: "FAC-200-002"
+ *                 statusCode:
+ *                   type: integer
+ *                   example: 200
+ *                 message:
+ *                   type: string
+ *                   example: "카테고리별 시설 검색 성공"
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     category:
+ *                       type: string
+ *                       example: "CAFE"
+ *                     facilities:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           id:
+ *                             type: string
+ *                             example: "12345"
+ *                           name:
+ *                             type: string
+ *                             example: "스타벅스 강남점"
+ *                           category:
+ *                             type: string
+ *                             example: "CAFE"
+ *                           lat:
+ *                             type: number
+ *                             example: 37.5012
+ *                           lng:
+ *                             type: number
+ *                             example: 127.0396
+ *                           address:
+ *                             type: string
+ *                             example: "서울시 강남구 테헤란로 123"
+ *                           roadAddress:
+ *                             type: string
+ *                             example: "서울시 강남구 테헤란로 123"
+ *                           phoneNumber:
+ *                             type: string
+ *                             nullable: true
+ *                             example: "02-1234-5678"
+ *                           distance:
+ *                             type: number
+ *                             description: 현재 위치로부터의 거리 (미터)
+ *                             example: 250
+ *                           thumbnailUrl:
+ *                             type: string
+ *                             nullable: true
+ *                             description: 장소 카카오맵 링크 (썸네일 대용)
+ *                             example: "http://place.map.kakao.com/12345"
+ *                           operatingHours:
+ *                             type: string
+ *                             description: 운영 시간 정보
+ *                             example: "평일 08:00-22:00"
+ *                           isOpen24Hours:
+ *                             type: boolean
+ *                             example: false
+ *                     totalCount:
+ *                       type: integer
+ *                       example: 8
+ *                     searchParams:
+ *                       type: object
+ *                       properties:
+ *                         latitude:
+ *                           type: number
+ *                           example: 37.5665
+ *                         longitude:
+ *                           type: number
+ *                           example: 126.9780
+ *                         radius:
+ *                           type: integer
+ *                           example: 1000
  *       400:
  *         description: 필수 파라미터 누락
  *       404:

--- a/src/routes/waitingPlace.route.js
+++ b/src/routes/waitingPlace.route.js
@@ -21,7 +21,7 @@ const router = express.Router();
 
 /**
  * @swagger
- * /api/v1/waiting-places:
+ * /api/waiting-places:
  *   get:
  *     summary: 첫 차 대기 장소 조회
  *     description: |
@@ -99,10 +99,19 @@ const router = express.Router();
  *                         type: number
  *                         example: 127.0396
  *                       distance:
- *                         type: number
- *                         description: 현재 위치로부터의 거리 (미터)
- *                         example: 250
- *       400:
+*                         type: number
+*                         description: 현재 위치로부터의 거리 (미터)
+*                         example: 250
+*                       thumbnailUrl:
+*                         type: string
+*                         nullable: true
+*                         description: 장소 카카오맵 링크 (썸네일 대용)
+*                         example: "http://place.map.kakao.com/12345"
+*                       operatingHours:
+*                         type: string
+*                         description: 운영 시간 정보
+*                         example: "24시간 영업"
+*       400:
  *         description: 잘못된 요청
  *         content:
  *           application/json:
@@ -125,7 +134,7 @@ router.get('/', (req, res, next) =>
 
 /**
  * @swagger
- * /api/v1/waiting-places/{placeId}/directions:
+ * /api/waiting-places/{placeId}/directions:
  *   get:
  *     summary: 대기 장소 길찾기
  *     description: |
@@ -209,7 +218,7 @@ router.get('/:placeId/directions', (req, res, next) =>
 
 /**
  * @swagger
- * /api/v1/waiting-places/{placeId}/deeplink:
+ * /api/waiting-places/{placeId}/deeplink:
  *   get:
  *     summary: 카카오맵 딥링크 생성
  *     description: |
@@ -300,7 +309,7 @@ router.get('/:placeId/deeplink', (req, res, next) =>
 
 /**
  * @swagger
- * /api/v1/waiting-places/{placeId}:
+ * /api/waiting-places/{placeId}:
  *   get:
  *     summary: 장소 상세 정보 조회
  *     description: |

--- a/src/services/facility.service.js
+++ b/src/services/facility.service.js
@@ -45,6 +45,7 @@ class FacilityService {
       }
 
       // 거리 계산 및 정렬
+      // 수정: thumbnailUrl과 operatingHours 추가
       const facilitiesWithDistance = facilities.map(facility => ({
         ...facility,
         distance: this.distanceUtil.calculate(
@@ -52,19 +53,25 @@ class FacilityService {
           longitude,
           facility.lat,
           facility.lng
-        )
+        ),
+        thumbnailUrl: facility.placeUrl || null, 
+        operatingHours: this._formatOperatingHours(facility)  
       }));
 
       const sortedFacilities = facilitiesWithDistance.sort((a, b) => a.distance - b.distance);
 
-      // 시설이 없는 경우
+      // 시설이 없는 경우 - 에러 대신 빈 배열 반환
       if (sortedFacilities.length === 0) {
-        throw new CustomError(
-          'FAC-404-001',
-          '주변에 시설이 없습니다',
-          '/facilities/search',
-          { searchArea: { latitude, longitude, radius } }
-        );
+        return {
+          facilities: [],
+          totalCount: 0,
+          searchParams: {
+            latitude,
+            longitude,
+            radius: radius || appConfig.search.defaultRadius,
+            keyword: keyword || null
+          }
+        };
       }
 
       return {
@@ -126,6 +133,7 @@ class FacilityService {
       const facilities = result.places;
 
       // 거리 계산 및 정렬
+      // 수정: thumbnailUrl과 operatingHours 추가
       const facilitiesWithDistance = facilities.map(facility => ({
         ...facility,
         distance: this.distanceUtil.calculate(
@@ -133,19 +141,25 @@ class FacilityService {
           longitude,
           facility.lat,
           facility.lng
-        )
+        ),
+        thumbnailUrl: facility.placeUrl || null,  
+        operatingHours: this._formatOperatingHours(facility) 
       }));
 
       const sortedFacilities = facilitiesWithDistance.sort((a, b) => a.distance - b.distance);
 
-      // 시설이 없는 경우
+      // 시설이 없는 경우 - 에러 대신 빈 배열 반환 
       if (sortedFacilities.length === 0) {
-        throw new CustomError(
-          'FAC-404-001',
-          `${categoryType} 카테고리의 시설이 없습니다`,
-          `/facilities/category/${categoryType}`,
-          { searchArea: { latitude, longitude, radius, categoryType } }
-        );
+        return {
+          category: categoryType,
+          facilities: [],
+          totalCount: 0,
+          searchParams: {
+            latitude,
+            longitude,
+            radius: radius || appConfig.search.defaultRadius
+          }
+        };
       }
 
       return {
@@ -188,6 +202,30 @@ class FacilityService {
         { originalError: error.message }
       );
     }
+  }
+
+  /**
+   * 운영시간 포맷팅 헬퍼 메서드
+   * 🆕 새로 추가된 메서드
+   */
+  _formatOperatingHours(facility) {
+    // 24시간 영업소인 경우
+    if (facility.isOpen24Hours) {
+      return '24시간 영업';
+    }
+    
+    // 카테고리별 일반적인 영업시간 (추정치)
+    const defaultHours = {
+      'CAFE': '평일 08:00-22:00',
+      'PC_ROOM': '24시간 영업',
+      'SAUNA': '06:00-22:00',
+      'RESTAURANT': '평일 11:00-22:00',
+      'PARK': '상시 개방',
+      'LIBRARY': '평일 09:00-18:00',
+      'SHOPPING_MALL': '평일 10:00-22:00'
+    };
+    
+    return defaultHours[facility.category] || '영업시간 정보 없음';
   }
 }
 

--- a/src/services/waitingPlace.service.js
+++ b/src/services/waitingPlace.service.js
@@ -16,7 +16,7 @@ class WaitingPlaceService {
         throw new CustomError(
           'COM-400-001',
           '필수 파라미터 누락',
-          '/api/v1/waiting-places/deeplink',
+          '/api/waiting-places/deeplink',
           { required: ['fromLat', 'fromLng', 'toLat', 'toLng'] }
         );
       }
@@ -27,7 +27,7 @@ class WaitingPlaceService {
         throw new CustomError(
           'MAP-400-001',
           '잘못된 좌표값',
-          '/api/v1/waiting-places/deeplink',
+          '/api/waiting-places/deeplink',
           { 
             from: { lat: deepLinkDto.fromLat, lng: deepLinkDto.fromLng },
             to: { lat: deepLinkDto.toLat, lng: deepLinkDto.toLng }
@@ -60,7 +60,7 @@ class WaitingPlaceService {
       throw new CustomError(
         'COM-500-001',
         '서버 내부 오류',
-        '/api/v1/waiting-places/deeplink',
+        '/api/waiting-places/deeplink',
         { originalError: error.message }
       );
     }
@@ -71,21 +71,21 @@ class WaitingPlaceService {
     const { lat, lng, category, openOnly, limit } = searchDto;
 
     // 필수 파라미터 검증
-    if (!lat || !lng) {
-      throw new CustomError(
-        'COM-400-001',
-        '필수 파라미터 누락',
-        '/api/v1/waiting-places',
-        { required: ['lat', 'lng'] }
-      );
-    }
+if (lat === undefined || lat === null || lng === undefined || lng === null) {
+  throw new CustomError(
+    'COM-400-001',
+    '필수 파라미터 누락',
+    '/api/waiting-places',  
+    { required: ['lat', 'lng'] }
+  );
+}
 
     // 좌표 유효성 검증
     if (!this._isValidCoordinate(lat, lng)) {
       throw new CustomError(
         'MAP-400-001',
         '잘못된 좌표값',
-        '/api/v1/waiting-places',
+        '/api/waiting-places',
         { lat, lng }
       );
     }
@@ -144,25 +144,32 @@ class WaitingPlaceService {
         ? placesWithDistance.filter(p => this._isCurrentlyOpen(p, currentTime))
         : placesWithDistance;
 
-      const sortedPlaces = filteredPlaces
-        .sort((a, b) => a.distance - b.distance)
-        .slice(0, limit);
+        
+      const MAX_DISTANCE = 5000; //반경 5km
 
-      // 장소가 없는 경우
+const sortedPlaces = filteredPlaces
+  .filter(p => p.distance <= MAX_DISTANCE)  // 거리 필터 추가
+  .sort((a, b) => a.distance - b.distance)
+  .slice(0, limit)
+
+      // 장소가 없는 경우 - 에러 대신 빈 배열 반환
       if (sortedPlaces.length === 0) {
-        throw new CustomError(
-          'MAP-404-001',
-          '주변에 대기 장소가 없습니다',
-          '/api/v1/waiting-places',
-          { searchArea: { lat, lng, radius: appConfig.search.defaultRadius } }
-        );
+        return {
+          places: [],
+          totalCount: 0
+        };
       }
 
       const enrichedPlaces = sortedPlaces.map(place => {
         const recommendReason = this._generateRecommendReason(place, currentTime);
         
         return new WaitingPlaceResponseDto(
-          { ...place, recommendReason },
+          { 
+            ...place, 
+            recommendReason,
+            thumbnailUrl: place.placeUrl || null,  
+            operatingHours: this._formatOperatingHours(place) 
+          },
           place.distance,
           currentTime
         );
@@ -187,7 +194,7 @@ class WaitingPlaceService {
         throw new CustomError(
           'MAP-500-001',
           '카카오 API 오류',
-          '/api/v1/waiting-places',
+          '/api/waiting-places',
           { 
             apiError: error.response.data?.message || error.message,
             statusCode: error.response.status 
@@ -199,7 +206,7 @@ class WaitingPlaceService {
       throw new CustomError(
         'COM-500-001',
         '서버 내부 오류',
-        '/api/v1/waiting-places',
+        '/api/waiting-places',
         { originalError: error.message }
       );
     }
@@ -211,7 +218,7 @@ class WaitingPlaceService {
       throw new CustomError(
         'COM-400-001',
         '장소 ID가 필요합니다',
-        `/api/v1/waiting-places/${placeId}`
+        `/api/waiting-places/${placeId}`
       );
     }
 
@@ -222,7 +229,7 @@ class WaitingPlaceService {
         throw new CustomError(
           'MAP-404-001',
           '대기 장소를 찾을 수 없습니다',
-          `/api/v1/waiting-places/${placeId}`,
+          `/api/waiting-places/${placeId}`,
           { placeId }
         );
       }
@@ -231,10 +238,15 @@ class WaitingPlaceService {
       const recommendReason = this._generateRecommendReason(place, currentTime);
       const kakaoMapUrl = this._generateKakaoMapDeepLink(place);
 
-      // 성공 시 데이터만 반환
+      // 성공 시 데이터만 반환 
       return {
         ...new WaitingPlaceResponseDto(
-          { ...place, recommendReason },
+          { 
+            ...place, 
+            recommendReason,
+            thumbnailUrl: place.placeUrl || null,       
+            operatingHours: this._formatOperatingHours(place)  
+          },
           0,
           currentTime
         ),
@@ -259,7 +271,7 @@ class WaitingPlaceService {
         throw new CustomError(
           'MAP-500-001',
           '카카오 API 오류',
-          `/api/v1/waiting-places/${placeId}`,
+          `/api/waiting-places/${placeId}`,
           { apiError: error.message }
         );
       }
@@ -268,7 +280,7 @@ class WaitingPlaceService {
       throw new CustomError(
         'COM-500-001',
         '서버 내부 오류',
-        `/api/v1/waiting-places/${placeId}`,
+        `/api/waiting-places/${placeId}`,
         { originalError: error.message }
       );
     }
@@ -282,7 +294,7 @@ class WaitingPlaceService {
       throw new CustomError(
         'COM-400-001',
         '필수 파라미터 누락',
-        `/api/v1/waiting-places/${placeId}/directions`,
+        `/api/waiting-places/${placeId}/directions`,
         { required: ['placeId', 'fromLat', 'fromLng'] }
       );
     }
@@ -292,7 +304,7 @@ class WaitingPlaceService {
       throw new CustomError(
         'MAP-400-001',
         '잘못된 좌표값',
-        `/api/v1/waiting-places/${placeId}/directions`,
+        `/api/waiting-places/${placeId}/directions`,
         { lat: fromLat, lng: fromLng }
       );
     }
@@ -304,7 +316,7 @@ class WaitingPlaceService {
         throw new CustomError(
           'MAP-404-001',
           '대기 장소를 찾을 수 없습니다',
-          `/api/v1/waiting-places/${placeId}/directions`,
+          `/api/waiting-places/${placeId}/directions`,
           { placeId }
         );
       }
@@ -353,7 +365,7 @@ class WaitingPlaceService {
         throw new CustomError(
           'MAP-404-002',
           '경로 탐색 실패',
-          `/api/v1/waiting-places/${placeId}/directions`,
+          `/api/waiting-places/${placeId}/directions`,
           { apiError: error.message }
         );
       }
@@ -362,7 +374,7 @@ class WaitingPlaceService {
       throw new CustomError(
         'COM-500-001',
         '서버 내부 오류',
-        `/api/v1/waiting-places/${placeId}/directions`,
+        `/api/waiting-places/${placeId}/directions`,
         { originalError: error.message }
       );
     }
@@ -422,6 +434,22 @@ class WaitingPlaceService {
       return true;
     }
     return true;
+  }
+  
+  _formatOperatingHours(place) {
+    // 24시간 영업소인 경우
+    if (place.isOpen24Hours) {
+      return '24시간 영업';
+    }
+    
+    // 카테고리별 일반적인 영업시간 (추정치)
+    const defaultHours = {
+      'CAFE': '평일 08:00-22:00',
+      'PC_ROOM': '24시간 영업',
+      'SAUNA': '06:00-22:00'
+    };
+    
+    return defaultHours[place.category] || '영업시간 정보 없음';
   }
 }
 


### PR DESCRIPTION
## 작업 내용

### 1. 썸네일 이미지 및 운영시간 정보 추가
- 대기 장소 조회 API 응답에 `thumbnailUrl`, `operatingHours` 필드 추가
- 카테고리별 기본 운영시간 정보 제공
- 카카오맵 링크를 썸네일 URL로 활용

### 2. RESTAURANT 카테고리 지원 추가
- `WaitingPlaceSearchDto`에 RESTAURANT 카테고리 추가
- `kakao.config.js`에 음식점 카테고리 코드(FD6) 추가
- Swagger 문서 업데이트

### 3. 빈 결과 처리 개선
- 장소가 없을 경우 500 에러 → 200 + 빈 배열로 응답 변경
- 사용자 경험 개선

### 4. 장소 상세 조회 캐싱 구현
- `KakaoMapClient`에 메모리 캐시 추가
- 검색 결과를 캐시에 저장하여 상세 조회 시 활용
- `getPlaceDetail` API 정상 작동

### 5. Swagger 문서 경로 수정
- 모든 엔드포인트 경로가 `/api/waiting-places`로 일관되게 수정
- 파라미터 이름 통일: `latitude/longitude` → `lat/lng`

---

## 수정된 파일

- `dtos/response/waitingPlace.dto.js` - 썸네일 및 운영시간 필드 추가
- `dtos/request/waitingPlaceSearch.dto.js` - RESTAURANT 카테고리 추가
- `config/kakao.config.js` - 음식점 카테고리 코드 추가
- `services/waitingPlace.service.js` - 빈 결과 처리 개선
- `clients/kakaoMap.client.js` - 메모리 캐싱 구현
- `routes/waitingPlace.route.js` - Swagger 문서 파라미터 수정
