### PR TITLE
🐛 feature/#57 : 자동 로그인 정책 수정

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -3,6 +3,8 @@ import { CustomSuccess } from '../response/customSuccess.js';
 import { CustomError } from '../response/customError.js'; //공통 응답 구조 사용함.
 
 const isProd = process.env.NODE_ENV === 'production'; //http 상태(웹 미배포)에서도 쿠키를 브라우저에서 받을 수 있도록 함.
+// 30일
+const REFRESH_COOKIE_MAX_AGE = 30 * 24 * 60 * 60 * 1000;
 
 //POST /auth/kakao 카카오 로그인 컨트롤러
 const kakaoLogin = async (req, res, next) => {
@@ -27,6 +29,7 @@ const kakaoLogin = async (req, res, next) => {
         secure: isProd, 
         // secure: true,
         sameSite: isProd ? 'none' : 'lax', 
+        maxAge: REFRESH_COOKIE_MAX_AGE, //기간 연장
         // sameSite: 'none',
       });
   
@@ -63,6 +66,7 @@ const kakaoLogin = async (req, res, next) => {
         secure: isProd,
         // secure: true,
         sameSite: isProd ? 'none' : 'lax', 
+        maxAge: REFRESH_COOKIE_MAX_AGE,
         //sameSite: 'none',
       });
   

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -63,7 +63,7 @@ const kakaoLogin = async (code, redirectUri ) => { // redirectUri 파라미터 �
 
     // Refresh Token
     const refreshToken = jwt.sign(payload, process.env.JWT_SECRET, {
-      expiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '14d',
+      expiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '30d',
     });
 
     // Refresh Token DB 저장 
@@ -131,7 +131,7 @@ const refresh = async (refreshToken) => {
     const newRefreshToken = jwt.sign(
       newPayload,
       process.env.JWT_SECRET,
-      { expiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '14d' }
+      { expiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '30d' }
     );
 
     // RT 교체 


### PR DESCRIPTION
### 주요 변경 사항
- 자동 로그인 유지 이슈 수정

###수정된 파일
-  src/services/auth.service.js : 리프레쉬 토큰 만료 기간을 30일로 통일함.
-  src/controllers/auth.controller.js : 리프레쉬 토큰 쿠키에 maxAge 옵션 추가 
- 브라우저 종료 시 로그아웃되던 현상을 수정함.

### 개선 효과
- 브라우저 종료 후 재접속 시에도 로그인 상태 유지
- Session Cookie로 인한 자동 로그아웃 문제 해결
- TTL 자동 만료 기능 활용 (3분)


---


## 📌 참고 사항(테스트 진행 방법)
- 카카오 로그인 진행
- DevTools → Application → Cookies
- refreshToken 쿠키의 Expires 값이 날짜로 표시되는지 확인
- 브라우저 완전 종료 후 재접속
- /auth/refresh 호출 후 로그인 상태 유지 확인