### PR TITLE
⚡️ feature/#55 : 알림 Map -> Redis 로 전환

### DIFF
--- a/src/services/notification.service.js
+++ b/src/services/notification.service.js
@@ -4,8 +4,10 @@ import { sendSMS } from "../utils/sms.util.js"; // SMS 발송 모듈 가정 (추
 import { getRouteToken, deleteRouteToken } from "../utils/routeTokenStore.util.js";
 import { recordRecentDestination } from "./recentDestination.service.js"; // 경로 확인!
 
+// export const registerNotification = async (userId, cacheKey, alert_time) => {
+//     const cachedData = getRouteToken(cacheKey);
 export const registerNotification = async (userId, cacheKey, alert_time) => {
-    const cachedData = getRouteToken(cacheKey);
+    const cachedData = await getRouteToken(cacheKey);
     
     // 캐시 데이터 존재 여부 확인
     if (!cachedData) {
@@ -74,7 +76,8 @@ export const registerNotification = async (userId, cacheKey, alert_time) => {
     });
 
     // 8. 캐시 삭제 및 SMS 발송
-    deleteRouteToken(cacheKey);
+    await deleteRouteToken(cacheKey);
+    // deleteRouteToken(cacheKey);
 
     const userPhoneNumber = result.user?.phone_number;
     if (userPhoneNumber) {

--- a/src/services/routeCandidate.service.js
+++ b/src/services/routeCandidate.service.js
@@ -797,7 +797,7 @@ export async function getRouteCandidates({ origin, destination }) {
     const route_token = generateRouteToken();
     const walkSegments = extractWalkSegments(c.detail);
 
-    setRouteToken(
+    await setRouteToken(
       route_token,
       {
         mapObj,
@@ -813,6 +813,23 @@ export async function getRouteCandidates({ origin, destination }) {
       },
       30 * 60,
     );
+
+    // setRouteToken(
+    //   route_token,
+    //   {
+    //     mapObj,
+    //     walkSegments,
+    //     snapshot: {
+    //       origin,
+    //       destination,
+    //       tags: c.tags,
+    //       station_id: c.station_id,
+    //       card: c.card,
+    //       detail: c.detail,
+    //     },
+    //   },
+    //   30 * 60,
+    // );
 
     c.route_token = route_token;
     finalPicked.push(c);

--- a/src/services/routePolyline.service.js
+++ b/src/services/routePolyline.service.js
@@ -51,10 +51,8 @@ function expandBoundary(boundary, paths) {
 
 export async function getPolylineByRouteToken({ routeToken }) {
   const PATH = `/api/routes/polylines/${routeToken}`;
+  const cached = await getRouteToken(routeToken);
 
-  const cached = getRouteToken(routeToken);
-
-  // 토큰 없음/만료
   if (!cached) {
     throwCustom(
       "MAP-410-001",
@@ -65,12 +63,29 @@ export async function getPolylineByRouteToken({ routeToken }) {
     );
   }
 
+// export async function getPolylineByRouteToken({ routeToken }) {
+//   const PATH = `/api/routes/polylines/${routeToken}`;
+
+//   const cached = getRouteToken(routeToken);
+
+//   // 토큰 없음/만료
+//   if (!cached) {
+//     throwCustom(
+//       "MAP-410-001",
+//       "경로 토큰이 만료되었거나 존재하지 않습니다.",
+//       PATH,
+//       410,
+//       null,
+//     );
+//   }
+
   const mapObject = cached?.mapObj;
   const walkSegments = cached?.walkSegments ?? [];
 
   // 토큰은 있는데 mapObject 없음
   if (!mapObject) {
-    deleteRouteToken(routeToken);
+    await deleteRouteToken(routeToken);
+    // deleteRouteToken(routeToken);
     throwCustom(
       "MAP-410-002",
       "mapObject가 없어 폴리라인을 생성할 수 없습니다. 경로를 다시 조회해주세요.",
@@ -82,7 +97,8 @@ export async function getPolylineByRouteToken({ routeToken }) {
 
   // mapObject가 이상 -> ODsay 호출 전에 컷 + 토큰 삭제
   if (!isLikelyValidOdsayMapObject(mapObject)) {
-    deleteRouteToken(routeToken);
+    // deleteRouteToken(routeToken);
+    await deleteRouteToken(routeToken);
     throwCustom(
       "MAP-422-001",
       "경로 폴리라인을 조회할 수 없습니다. 경로를 다시 조회해주세요.",
@@ -126,7 +142,8 @@ export async function getPolylineByRouteToken({ routeToken }) {
 
     // -8: mapObject 형식 오류
     if (code === "-8") {
-      deleteRouteToken(routeToken);
+      await deleteRouteToken(routeToken);
+      // deleteRouteToken(routeToken);
       throwCustom(
         "MAP-422-001",
         "경로 폴리라인을 조회할 수 없습니다. 다시 경로를 조회해주세요.",

--- a/src/utils/routeTokenStore.util.js
+++ b/src/utils/routeTokenStore.util.js
@@ -1,8 +1,12 @@
-const store = new Map(); // token -> { value, expiresAt }
+import redis from "../config/redis.js";
+
+
+// const store = new Map(); // token -> { value, expiresAt }
 
 // cleanup
-const CLEANUP_INTERVAL_MS = 60 * 1000; // 1분
-const ENABLE_CLEANUP = process.env.ROUTE_TOKEN_CLEANUP !== "false";
+// const CLEANUP_INTERVAL_MS = 60 * 1000; // 1분
+// const ENABLE_CLEANUP = process.env.ROUTE_TOKEN_CLEANUP !== "false";
+
 
 function cleanupExpiredTokens() {
   const now = Date.now();
@@ -20,22 +24,50 @@ if (ENABLE_CLEANUP) {
   if (typeof cleanupTimer.unref === "function") cleanupTimer.unref();
 }
 
-export function setRouteToken(token, value, ttlSec = 60 * 30) {
-  const expiresAt = Date.now() + ttlSec * 1000;
-  store.set(token, { value, expiresAt });
+export async function setRouteToken(token, value, ttlSec = 60 * 30) {
+  const key = `route_token:${token}`;
+  await redis.set(
+    key,
+    JSON.stringify(value),
+    "EX",
+    ttlSec
+  );
 }
 
-export function getRouteToken(token) {
-  const hit = store.get(token);
-  if (!hit) return null;
+// export function setRouteToken(token, value, ttlSec = 60 * 30) {
+//   const expiresAt = Date.now() + ttlSec * 1000;
+//   store.set(token, { value, expiresAt });
+// }
 
-  if (Date.now() > hit.expiresAt) {
-    store.delete(token);
+// export function getRouteToken(token) {
+//   const hit = store.get(token);
+//   if (!hit) return null;
+
+//   if (Date.now() > hit.expiresAt) {
+//     store.delete(token);
+//     return null;
+//   }
+//   return hit.value;
+// }
+
+export async function getRouteToken(token) {
+  const key = `route_token:${token}`;
+  const raw = await redis.get(key);
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    await redis.del(key);
     return null;
   }
-  return hit.value;
 }
 
-export function deleteRouteToken(token) {
-  store.delete(token);
+export async function deleteRouteToken(token) {
+  const key = `route_token:${token}`;
+  await redis.del(key);
 }
+
+// export function deleteRouteToken(token) {
+//   store.delete(token);
+// }


### PR DESCRIPTION
### 주요 변경 사항
- route_token 저장 방식을 in-memory Map → Redis로 전환
- 비동기 Redis I/O에 맞게 호출부 await 누락 버그 수정
- 토큰 만료 및 삭제 로직 안정화

###수정된 파일
-  src/utils/routeTokenStore.util.js: Map 기반 토큰 저장소 제거, Redis 기반 저장/조회/삭제 로직으로 변경
-  src/controllers/auth.controller.js : setRouteToken 호출부를 비동기 방식으로 수정
- src/services/polyline.service.js : getRouteToken, deleteRouteToken 호출부에 await 적용,
- src/services/notification.service.js : 알림 등록 시 Redis 기반 route_token 조회/삭제 처리

### 개선 효과
- 서버 재시작, 다중 인스턴스 환경에서도 route_token 유실 문제 해결
- TTL 기반 자동 만료로 메모리 누수 방지
- 비동기 처리 누락으로 인한 런타임 버그 제가

---


## 📌 참고 사항
- route_token 저장소를 Map에서 Redis로 전환하여 멀티 인스턴스 환경에서의 토큰 유실 문제를 해결