### PR TITLE
feature/#58 도메인 쿠키 공유 및 인증 에러 처리 개선

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -25,11 +25,38 @@ app.use(express.json());
 app.use(cookieParser());
 
 // CORS - 쿠키 전송 필수
+const isProd = process.env.NODE_ENV === 'production';
+
+const allowedOrigins = isProd 
+  ? [
+      'https://makcha.vercel.app',
+      'https://www.makcha.store',  // 병재님이 DNS 추가하면 이것도 사용
+      'https://makcha.store',      // www 없는 버전도 대비
+    ]
+  : [
+      'http://localhost:3000',
+      'http://localhost:5173',     // Vite 기본 포트
+      'http://127.0.0.1:3000',
+      'http://127.0.0.1:5173',
+    ];
+
 app.use(
   cors({
-    origin: true, // 요청 origin 그대로 허용, 쿠키 인증 + HTTPS + Nginx 환경에서 안정. 아직 웹배포 전이므로.
-    credentials: true,
-  }),
+    origin: (origin, callback) => {
+      // origin이 없는 경우 (Postman, curl, 모바일 앱 등)는 허용
+      if (!origin) return callback(null, true);
+      
+      if (allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        console.warn(` CORS blocked: ${origin}`);
+        callback(new Error('Not allowed by CORS'));
+      }
+    },
+    credentials: true,  // 쿠키 전송 필수
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  })
 );
 
 // 라우터 연결

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -6,6 +6,16 @@ const isProd = process.env.NODE_ENV === 'production'; //http 상태(웹 미배�
 // 30일
 const REFRESH_COOKIE_MAX_AGE = 30 * 24 * 60 * 60 * 1000;
 
+// 쿠키 옵션을 별도로 정의
+const getCookieOptions = () => ({
+  httpOnly: true,
+  secure: true, // 프로덕션에서는 항상 true
+  sameSite: 'none', // 크로스 도메인을 위해 'none'으로 설정
+  maxAge: REFRESH_COOKIE_MAX_AGE,
+  domain: isProd ? '.makcha.store' : undefined, // 서브도메인 간 공유
+  path: '/',
+});
+
 //POST /auth/kakao 카카오 로그인 컨트롤러
 const kakaoLogin = async (req, res, next) => {
     try {
@@ -22,16 +32,9 @@ const kakaoLogin = async (req, res, next) => {
       
       // redirectUri를 service로 전달
       const result = await authService.kakaoLogin(code, redirectUri);
-  
-      // Refresh Token 쿠키 저장
-      res.cookie('refreshToken', result.refreshToken, {
-        httpOnly: true,
-        secure: isProd, 
-        // secure: true,
-        sameSite: isProd ? 'none' : 'lax', 
-        maxAge: REFRESH_COOKIE_MAX_AGE, //기간 연장
-        // sameSite: 'none',
-      });
+      
+      // 수정된 쿠키 옵션 사용
+      res.cookie('refreshToken', result.refreshToken, getCookieOptions());
   
       const response = new CustomSuccess(
         'AUTH-200-001',
@@ -61,14 +64,7 @@ const kakaoLogin = async (req, res, next) => {
   
       const result = await authService.refresh(refreshToken);
   
-      res.cookie('refreshToken', result.refreshToken, {
-        httpOnly: true,
-        secure: isProd,
-        // secure: true,
-        sameSite: isProd ? 'none' : 'lax', 
-        maxAge: REFRESH_COOKIE_MAX_AGE,
-        //sameSite: 'none',
-      });
+      res.cookie('refreshToken', result.refreshToken, getCookieOptions());
   
       const response = new CustomSuccess(
         'AUTH-200-002',
@@ -91,11 +87,7 @@ const logout = async (req, res, next) => {
     await authService.logout(userId);
 
     // refreshToken 쿠키 삭제
-    res.clearCookie('refreshToken', {
-      httpOnly: true,
-      secure: isProd,
-      sameSite: isProd ? 'none' : 'lax',
-    });
+    res.clearCookie('refreshToken', getCookieOptions());
 
     const response = new CustomSuccess(
       'AUTH-200-004',
@@ -117,11 +109,7 @@ const withdraw = async (req, res, next) => {
     await authService.withdraw(user);
 
     // refreshToken 쿠키 삭제
-    res.clearCookie('refreshToken', {
-      httpOnly: true,
-      secure: isProd,
-      sameSite: isProd ? 'none' : 'lax',
-    });
+    res.clearCookie('refreshToken', getCookieOptions());
 
     const response = new CustomSuccess(
       'AUTH-200-005',

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -142,6 +142,19 @@ const refresh = async (refreshToken) => {
       refreshToken: newRefreshToken,
     };
   } catch (err) {
+    // JWT 에러는 401로 처리
+    if (err.name === 'JsonWebTokenError' || err.name === 'TokenExpiredError') {
+      throw new CustomError(
+        'AUTH-401-004',
+        'Refresh Token 만료 또는 오류',
+        'auth.service.refresh'
+      );
+    }
+    // CustomError는 그대로 throw
+    if (err instanceof CustomError) {
+      throw err;
+    }
+    // 그 외 에러는 401로 처리 (500 방지)
     throw new CustomError(
       'AUTH-401-004',
       'Refresh Token 만료 또는 오류',


### PR DESCRIPTION
### 주요 변경 사항
- 크로스 도메인 환경에서 쿠키(refreshToken) 공유 가능하도록 설정 개선
- CORS 설정을 프로덕션 환경에 맞게 명시적으로 지정
- 인증 에러 처리를 500 → 401로 통일하여 클라이언트 에러 핸들링 개선

### 수정된 파일
- `src/app.js`: CORS 설정 개선, 허용 origin 명시적 지정 및 credentials 활성화
- `src/controllers/auth.controller.js`: 쿠키 옵션 통합 함수(`getCookieOptions`) 추가, 크로스 도메인 대응 설정 적용
- `src/services/auth.service.js`: refresh token 관련 에러를 401로 통일, JWT 에러 타입별 분기 처리 추가
- `.env`: 프로덕션 환경에 맞게 리다이렉트 URI 및 토큰 만료 기간 수정

### 개선 효과
- 서브도메인 간 쿠키 공유로 시크릿 모드 및 모바일 웹앱에서 로그인 세션 유지
- HTTPS 크로스 도메인 환경에서 안정적인 쿠키 전송
- 인증 실패 시 명확한 401 에러 반환으로 클라이언트 측 에러 핸들링 개선
- 환경별 CORS origin 분리로 보안 강화

---

## 📌 참고 사항
- 쿠키 도메인을 `.makcha.store`로 설정하여 `api.makcha.store`와 `www.makcha.store` 간 쿠키 공유
- `sameSite: 'none'`, `secure: true` 설정으로 HTTPS 크로스 사이트 요청 지원
- JWT 에러(`JsonWebTokenError`, `TokenExpiredError`) 및 모든 인증 실패를 401로 통일 처리