### PR TITLE
fix: CORS 설정을 개발/운영 환경 모두 허용하도록 수정

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -24,21 +24,32 @@ const app = express();
 app.use(express.json());
 app.use(cookieParser());
 
-// CORS - 쿠키 전송 필수
-const isProd = process.env.NODE_ENV === 'production';
+// CORS - 개발/운영 모두 허용으로 수정
+const allowedOrigins = [
+  // 운영 환경
+  'https://makcha.vercel.app',
+  'https://www.makcha.store',
+  'https://makcha.store',
+  // 개발 환경
+  'http://localhost:3000',
+  'http://localhost:5173',
+  'http://127.0.0.1:3000',
+  'http://127.0.0.1:5173',
+];
+// const isProd = process.env.NODE_ENV === 'production';
 
-const allowedOrigins = isProd 
-  ? [
-      'https://makcha.vercel.app',
-      'https://www.makcha.store',  // 병재님이 DNS 추가하면 이것도 사용
-      'https://makcha.store',      // www 없는 버전도 대비
-    ]
-  : [
-      'http://localhost:3000',
-      'http://localhost:5173',     // Vite 기본 포트
-      'http://127.0.0.1:3000',
-      'http://127.0.0.1:5173',
-    ];
+// const allowedOrigins = isProd 
+//   ? [
+//       'https://makcha.vercel.app',
+//       'https://www.makcha.store',  // 병재님이 DNS 추가하면 이것도 사용
+//       'https://makcha.store',      // www 없는 버전도 대비
+//     ]
+//   : [
+//       'http://localhost:3000',
+//       'http://localhost:5173',     // Vite 기본 포트
+//       'http://127.0.0.1:3000',
+//       'http://127.0.0.1:5173',
+//     ];
 
 app.use(
   cors({


### PR DESCRIPTION
### 주요 변경 사항
- `isProd` 환경 변수 분기 로직 제거
- 개발 환경과 운영 환경 origin을 단일 배열로 통합
- 로컬 개발 환경 (`localhost:3000`, `localhost:5173` 등) 상시 허용

### 수정된 파일
- `src/app.js`: `isProd` 환경 변수 분기 로직 제거
---

## 📌 참고 사항
-프론트엔드 팀이 로컬에서 배포된 백엔드 API 테스트 가능