### PR TITLE
 Fix/#100 대기 장소 및 시설 API 오류 수정

### DIFF
--- a/src/controllers/waitingPlace.controller.js
+++ b/src/controllers/waitingPlace.controller.js
@@ -90,6 +90,7 @@ class WaitingPlaceController {
   async getPlaceDetail(req, res, next) {
     try {
       const { placeId } = req.params;
+      const { lat, lng } = req.query;  // 사용자 위치 받기
 
       if (!placeId) {
         // CustomError 사용
@@ -100,7 +101,12 @@ class WaitingPlaceController {
         );
       }
 
-      const result = await this.service.getPlaceDetail(placeId);
+      // lat, lng 파라미터 추가
+      const result = await this.service.getPlaceDetail(
+        placeId,
+        lat ? parseFloat(lat) : null,
+        lng ? parseFloat(lng) : null
+      );
 
       // CustomSuccess 사용
       const response = new CustomSuccess(

--- a/src/dtos/response/waitingPlace.dto.js
+++ b/src/dtos/response/waitingPlace.dto.js
@@ -12,13 +12,15 @@ export class WaitingPlaceResponseDto {
     this.closingTime = place.closingTime;
     this.phoneNumber = place.phoneNumber;
     this.address = place.address || null;
-    this.isCurrentlyOpen = this._checkOpen(place, currentTime);
+    this.isCurrentlyOpen = place.isCurrentlyOpen !== undefined 
+      ? place.isCurrentlyOpen 
+      : this._checkOpen(place, currentTime);  // Service에서 전달받은 값 우선
     this.recommendReason = place.recommendReason || '';
     this.source = place.source || 'db';
     
-    // ⭐ 썸네일과 운영시간 추가
-    this.thumbnailUrl = place.thumbnailUrl || place.placeUrl || null;
-    this.operatingHours = place.operatingHours || this._getDefaultOperatingHours(place.category, place.isOpen24Hours);
+    // Service에서 전달된 값을 그대로 사용 (기본값 제거)
+    this.thumbnailUrl = place.thumbnailUrl || null;  // placeUrl 폴백 제거
+    this.operatingHours = place.operatingHours || null;  // 기본값 제거
   }
 
   _checkOpen(place, currentTime) {
@@ -34,21 +36,5 @@ export class WaitingPlaceResponseDto {
     }
     
     return now < closing;
-  }
-  
-  // ⭐ 기본 운영시간 생성 메서드 추가
-  _getDefaultOperatingHours(category, isOpen24Hours) {
-    if (isOpen24Hours) {
-      return '24시간 영업';
-    }
-    
-    const defaultHours = {
-      'CAFE': '평일 08:00-22:00',
-      'PC_ROOM': '24시간 영업',
-      'SAUNA': '06:00-22:00',
-      'RESTAURANT': '평일 11:00-21:00'
-    };
-    
-    return defaultHours[category] || '영업시간 정보 없음';
   }
 }

--- a/src/services/facility.service.js
+++ b/src/services/facility.service.js
@@ -44,8 +44,9 @@ class FacilityService {
         facilities = results.flatMap(r => r.places);
       }
 
-      // 거리 계산 및 정렬
-      // 수정: thumbnailUrl과 operatingHours 추가
+      const currentTime = new Date();
+
+      // 거리 계산 및 필드 추가
       const facilitiesWithDistance = facilities.map(facility => ({
         ...facility,
         distance: this.distanceUtil.calculate(
@@ -54,8 +55,9 @@ class FacilityService {
           facility.lat,
           facility.lng
         ),
-        thumbnailUrl: facility.placeUrl || null, 
-        operatingHours: this._formatOperatingHours(facility)  
+        thumbnailUrl: null,  // 카카오 API는 이미지 미제공
+        operatingHours: this._formatOperatingHours(facility), 
+        isCurrentlyOpen: this._isCurrentlyOpen(facility, currentTime)  
       }));
 
       const sortedFacilities = facilitiesWithDistance.sort((a, b) => a.distance - b.distance);
@@ -131,9 +133,9 @@ class FacilityService {
       });
 
       const facilities = result.places;
+      const currentTime = new Date();
 
-      // 거리 계산 및 정렬
-      // 수정: thumbnailUrl과 operatingHours 추가
+      // 거리 계산 및 필드 추가
       const facilitiesWithDistance = facilities.map(facility => ({
         ...facility,
         distance: this.distanceUtil.calculate(
@@ -142,8 +144,9 @@ class FacilityService {
           facility.lat,
           facility.lng
         ),
-        thumbnailUrl: facility.placeUrl || null,  
-        operatingHours: this._formatOperatingHours(facility) 
+        thumbnailUrl: null,  // 카카오 API는 이미지 미제공
+        operatingHours: this._formatOperatingHours(facility),  
+        isCurrentlyOpen: this._isCurrentlyOpen(facility, currentTime)  
       }));
 
       const sortedFacilities = facilitiesWithDistance.sort((a, b) => a.distance - b.distance);
@@ -204,28 +207,32 @@ class FacilityService {
     }
   }
 
-  /**
-   * 운영시간 포맷팅 헬퍼 메서드
-   * 🆕 새로 추가된 메서드
+  /*
+   운영시간 포맷팅 헬퍼 메서드
    */
   _formatOperatingHours(facility) {
-    // 24시간 영업소인 경우
+    // 24시간 영업인 경우
     if (facility.isOpen24Hours) {
       return '24시간 영업';
     }
     
-    // 카테고리별 일반적인 영업시간 (추정치)
-    const defaultHours = {
-      'CAFE': '평일 08:00-22:00',
-      'PC_ROOM': '24시간 영업',
-      'SAUNA': '06:00-22:00',
-      'RESTAURANT': '평일 11:00-22:00',
-      'PARK': '상시 개방',
-      'LIBRARY': '평일 09:00-18:00',
-      'SHOPPING_MALL': '평일 10:00-22:00'
-    };
+    // 카카오 API는 영업시간 상세 정보를 제공하지 않음
+    // null 반환 (프론트에서 처리)
+    return null;
+  }
+
+  /**
+   현재 영업 중인지 확인하는 헬퍼 메서드
+   */
+  _isCurrentlyOpen(facility, currentTime) {
+    // 24시간 영업이면 항상 true
+    if (facility.isOpen24Hours) {
+      return true;
+    }
     
-    return defaultHours[facility.category] || '영업시간 정보 없음';
+    // 실제 영업시간 체크는 추후 구현
+    // 현재는 카카오 API에서 정확한 영업시간 파싱이 어려워 일단 true 반환
+    return true;
   }
 }
 

--- a/src/services/waitingPlace.service.js
+++ b/src/services/waitingPlace.service.js
@@ -71,14 +71,14 @@ class WaitingPlaceService {
     const { lat, lng, category, openOnly, limit } = searchDto;
 
     // 필수 파라미터 검증
-if (lat === undefined || lat === null || lng === undefined || lng === null) {
-  throw new CustomError(
-    'COM-400-001',
-    '필수 파라미터 누락',
-    '/api/waiting-places',  
-    { required: ['lat', 'lng'] }
-  );
-}
+    if (lat === undefined || lat === null || lng === undefined || lng === null) {
+      throw new CustomError(
+        'COM-400-001',
+        '필수 파라미터 누락',
+        '/api/waiting-places',  
+        { required: ['lat', 'lng'] }
+      );
+    }
 
     // 좌표 유효성 검증
     if (!this._isValidCoordinate(lat, lng)) {
@@ -147,10 +147,10 @@ if (lat === undefined || lat === null || lng === undefined || lng === null) {
         
       const MAX_DISTANCE = 5000; //반경 5km
 
-const sortedPlaces = filteredPlaces
-  .filter(p => p.distance <= MAX_DISTANCE)  // 거리 필터 추가
-  .sort((a, b) => a.distance - b.distance)
-  .slice(0, limit)
+      const sortedPlaces = filteredPlaces
+        .filter(p => p.distance <= MAX_DISTANCE)  // 거리 필터 추가
+        .sort((a, b) => a.distance - b.distance)
+        .slice(0, limit);
 
       // 장소가 없는 경우 - 에러 대신 빈 배열 반환
       if (sortedPlaces.length === 0) {
@@ -167,8 +167,9 @@ const sortedPlaces = filteredPlaces
           { 
             ...place, 
             recommendReason,
-            thumbnailUrl: place.placeUrl || null,  
-            operatingHours: this._formatOperatingHours(place) 
+            thumbnailUrl: null,  // 카카오 API는 이미지 미제공
+            operatingHours: this._formatOperatingHours(place),  
+            isCurrentlyOpen: this._isCurrentlyOpen(place, currentTime)
           },
           place.distance,
           currentTime
@@ -212,7 +213,7 @@ const sortedPlaces = filteredPlaces
     }
   }
 
-  async getPlaceDetail(placeId) {
+  async getPlaceDetail(placeId, userLat, userLng) {  // 파라미터 추가
     // 필수 파라미터 검증
     if (!placeId) {
       throw new CustomError(
@@ -238,16 +239,28 @@ const sortedPlaces = filteredPlaces
       const recommendReason = this._generateRecommendReason(place, currentTime);
       const kakaoMapUrl = this._generateKakaoMapDeepLink(place);
 
+      // ✅ 수정: 거리 계산 추가
+      let distance = 0;
+      if (userLat && userLng && this._isValidCoordinate(userLat, userLng)) {
+        distance = this.distanceUtil.calculate(
+          userLat, 
+          userLng, 
+          place.lat, 
+          place.lng
+        );
+      }
+
       // 성공 시 데이터만 반환 
       return {
         ...new WaitingPlaceResponseDto(
           { 
             ...place, 
             recommendReason,
-            thumbnailUrl: place.placeUrl || null,       
-            operatingHours: this._formatOperatingHours(place)  
+            thumbnailUrl: null,  // 카카오 API는 이미지 미제공
+            operatingHours: this._formatOperatingHours(place),  
+            isCurrentlyOpen: this._isCurrentlyOpen(place, currentTime) 
           },
-          0,
+          Math.round(distance),  // 0 → 실제 거리
           currentTime
         ),
         kakaoMapUrl,
@@ -433,23 +446,20 @@ const sortedPlaces = filteredPlaces
     if (place.isOpen24Hours) {
       return true;
     }
+    // 실제 영업시간 체크는 추후 구현
+    // 현재는 카카오 API에서 정확한 영업시간 파싱이 어려워 일단 true 반환
     return true;
   }
   
   _formatOperatingHours(place) {
-    // 24시간 영업소인 경우
+    // 24시간 영업인 경우
     if (place.isOpen24Hours) {
       return '24시간 영업';
     }
     
-    // 카테고리별 일반적인 영업시간 (추정치)
-    const defaultHours = {
-      'CAFE': '평일 08:00-22:00',
-      'PC_ROOM': '24시간 영업',
-      'SAUNA': '06:00-22:00'
-    };
-    
-    return defaultHours[place.category] || '영업시간 정보 없음';
+    // 카카오 API는 영업시간 상세 정보를 제공하지 않음
+    // null 반환 (프론트에서 처리)
+    return null;
   }
 }
 


### PR DESCRIPTION
Closes #100

### 📋 수정 내용

**1. operatingHours 고정값 문제**
- Before: 모든 장소가 "평일 08:00-22:00" 동일한 값
- After: 
  - 24시간 영업: `"24시간 영업"` 문자열
  - 일반 영업: `null` (카카오 API 제약)

**2. thumbnailUrl 카카오맵 링크 문제**
- Before: 카카오맵 웹 링크 (`place.placeUrl`)
- After: `null` (카카오 API에서 이미지 미제공)

**3. distance 0 문제**
- Before: 상세 조회 시 항상 `0`
- After: 사용자 위치 기반 실제 거리 계산
- 변경: 상세 조회 시 쿼리 파라미터 `lat`, `lng` 필요
```
  GET /api/waiting-places/:placeId?lat=37.5665&lng=126.9780
```

**4. 식당 카테고리 500 오류**
- Before: `/api/facilities/category/RESTAURANT` 호출 시 500 에러
- After: 정상 응답

**5. isCurrentlyOpen 필드 추가**
- 모든 대기 장소 및 시설 응답에 추가
- 현재: 24시간 영업 → `true`, 일반 → `true` (추후 개선 예정)

---

### 🔧 변경 파일

#### 대기 장소 API
- `src/services/waitingPlace.service.js`
  - `_formatOperatingHours()`: null 반환 로직
  - `getPlaceDetail()`: lat, lng로 거리 계산
  - thumbnailUrl null 처리
  - isCurrentlyOpen 추가

- `src/controllers/waitingPlace.controller.js`
  - `getPlaceDetail()`: lat, lng 파라미터 받기

- `src/dtos/response/waitingPlace.dto.js`
  - Service 전달 값 우선 사용
  - 기본값 강제 설정 제거

#### 시설 API
- `src/services/facility.service.js`
  - `_formatOperatingHours()`: null 반환
  - `_isCurrentlyOpen()`: 추가
  - thumbnailUrl null 처리

---

### ✅ 테스트 완료

- [x] 대기 장소 목록 조회
- [x] 대기 장소 상세 조회 (distance 확인)
- [x] 식당 카테고리 조회 (500 오류 해결)
- [x] thumbnailUrl: null
- [x] operatingHours: null 또는 "24시간 영업"
- [x] isCurrentlyOpen: true

---

#### 카카오맵 API 제약
- 이미지 URL 미제공 → `thumbnailUrl` 항상 `null`
- 상세 영업시간 미제공 → `operatingHours` null 또는 "24시간 영업"

#### 프론트엔드 처리 필요
- `thumbnailUrl === null` → 기본 이미지 표시
- `operatingHours === null` → "영업시간 정보 없음" 표시

#### API 사용 변경
대기 장소 상세 조회 시:
```
GET /api/waiting-places/:placeId?lat=37.5665&lng=126.9780
```