### PR TITLE
Feature/#104 sort 파라미터 추가

### DIFF
--- a/src/dtos/request/waitingPlaceSearch.dto.js
+++ b/src/dtos/request/waitingPlaceSearch.dto.js
@@ -1,16 +1,17 @@
 export class WaitingPlaceSearchDto {
-  constructor({ lat, lng, category, openOnly = true, limit = 10 }) {
+  constructor({ lat, lng, category, openOnly = true, limit = 10, sort = 'distance' }) {  
     this.lat = parseFloat(lat);
     this.lng = parseFloat(lng);
     this.category = category || null;
     this.openOnly = openOnly === true || openOnly === 'true';
     this.limit = parseInt(limit);
+    this.sort = sort || 'distance';  
   }
 
   validate() {
     const errors = [];
 
-    // 수정: lat === undefined || lat === null 체크로 변경
+    // lat === undefined || lat === null 체크로 변경
     if (this.lat === undefined || this.lat === null || isNaN(this.lat) || this.lat < -90 || this.lat > 90) {
       errors.push({ 
         field: 'lat', 
@@ -18,7 +19,7 @@ export class WaitingPlaceSearchDto {
       });
     }
 
-    // 수정: lng === undefined || lng === null 체크로 변경
+    // lng === undefined || lng === null 체크로 변경
     if (this.lng === undefined || this.lng === null || isNaN(this.lng) || this.lng < -180 || this.lng > 180) {
       errors.push({ 
         field: 'lng', 
@@ -26,7 +27,7 @@ export class WaitingPlaceSearchDto {
       });
     }
 
-    // ⭐ RESTAURANT 추가
+    // RESTAURANT 추가
     if (this.category && !['CAFE', 'PC_ROOM', 'SAUNA', 'RESTAURANT'].includes(this.category)) {
       errors.push({ 
         field: 'category', 
@@ -38,6 +39,15 @@ export class WaitingPlaceSearchDto {
       errors.push({ 
         field: 'limit', 
         message: 'limit은 1에서 50 사이여야 합니다.' 
+      });
+    }
+
+    // sort 유효성 검증 추가
+    const validSortOptions = ['distance', '24hour'];
+    if (!validSortOptions.includes(this.sort)) {
+      errors.push({ 
+        field: 'sort', 
+        message: `sort는 ${validSortOptions.join(', ')} 중 하나여야 합니다.` 
       });
     }
 

--- a/src/services/waitingPlace.service.js
+++ b/src/services/waitingPlace.service.js
@@ -68,7 +68,7 @@ class WaitingPlaceService {
 
   async findNearbyPlaces(searchDto) {
     const currentTime = new Date();
-    const { lat, lng, category, openOnly, limit } = searchDto;
+    const { lat, lng, category, openOnly, limit, sort } = searchDto;  
 
     // 필수 파라미터 검증
     if (lat === undefined || lat === null || lng === undefined || lng === null) {
@@ -147,10 +147,11 @@ class WaitingPlaceService {
         
       const MAX_DISTANCE = 5000; //반경 5km
 
-      const sortedPlaces = filteredPlaces
-        .filter(p => p.distance <= MAX_DISTANCE)  // 거리 필터 추가
-        .sort((a, b) => a.distance - b.distance)
-        .slice(0, limit);
+      // 정렬 로직 적용
+      const sortedPlaces = this._sortPlaces(
+        filteredPlaces.filter(p => p.distance <= MAX_DISTANCE),
+        sort
+      ).slice(0, limit);
 
       // 장소가 없는 경우 - 에러 대신 빈 배열 반환
       if (sortedPlaces.length === 0) {
@@ -239,7 +240,7 @@ class WaitingPlaceService {
       const recommendReason = this._generateRecommendReason(place, currentTime);
       const kakaoMapUrl = this._generateKakaoMapDeepLink(place);
 
-      // ✅ 수정: 거리 계산 추가
+      // 거리 계산 추가
       let distance = 0;
       if (userLat && userLng && this._isValidCoordinate(userLat, userLng)) {
         distance = this.distanceUtil.calculate(
@@ -393,7 +394,7 @@ class WaitingPlaceService {
     }
   }
 
-  // 좌표 유효성 검증 헬퍼 메서드 추가
+  // 좌표 유효성 검증 헬퍼 메서드
   _isValidCoordinate(lat, lng) {
     const latitude = parseFloat(lat);
     const longitude = parseFloat(lng);
@@ -460,6 +461,31 @@ class WaitingPlaceService {
     // 카카오 API는 영업시간 상세 정보를 제공하지 않음
     // null 반환 (프론트에서 처리)
     return null;
+  }
+
+  /**
+   * 정렬 로직
+   * @param {Array} places - 정렬할 장소 목록
+   * @param {string} sortOption - 정렬 옵션 ('distance' 또는 '24hour')
+   * @returns {Array} 정렬된 장소 목록
+   */
+  _sortPlaces(places, sortOption) {
+    switch (sortOption) {
+      case '24hour':
+        // 24시간 영업소 우선, 그 다음 거리순
+        return places.sort((a, b) => {
+          // 24시간 영업 여부로 먼저 정렬
+          if (a.isOpen24Hours && !b.isOpen24Hours) return -1;
+          if (!a.isOpen24Hours && b.isOpen24Hours) return 1;
+          // 같은 24시간 상태면 거리순
+          return a.distance - b.distance;
+        });
+        
+      case 'distance':
+      default:
+        // 거리순 정렬 (기본값)
+        return places.sort((a, b) => a.distance - b.distance);
+    }
   }
 }
 


### PR DESCRIPTION
첫차 대기 장소 조회 시 정렬 기능을 쿼리 파라미터로 처리

### 🎯 구현 내용

**sort 쿼리 파라미터 추가**
- `sort=distance` (기본값): 거리순 정렬
- `sort=24hour`: 24시간 영업소 우선, 그 다음 거리순

**사용 예시:**
```bash
# 거리순 (기본)
GET /api/waiting-places?lat=37.5665&lng=126.9780

# 24시간 영업소 우선
GET /api/waiting-places?lat=37.5665&lng=126.9780&sort=24hour
```

---

### 🔧 변경 파일

**1. WaitingPlaceSearchDto**
- sort 필드 추가 (기본값: 'distance')
- sort 유효성 검증 추가

**2. WaitingPlaceService**
- _sortPlaces 메서드 추가
- findNearbyPlaces에 정렬 로직 적용

---

### 📊 정렬 로직

**distance (기본값)**
```
1. 카페A - 150m
2. PC방B - 320m
3. 카페C - 450m (24시간)
4. 찜질방D - 800m (24시간)
```

**24hour**
```
1. 카페C - 450m (24시간) ✅
2. 찜질방D - 800m (24시간) ✅
3. 카페A - 150m
4. PC방B - 320m
```

---

### ✅ 테스트 완료

- [x] 거리순 정렬 (sort=distance) 동작 확인
- [x] 24시간 우선 정렬 (sort=24hour) 동작 확인
- [x] 잘못된 sort 값 검증 확인
- [x] sort 파라미터 생략 시 기본값 적용 확인

