### PR TITLE
Fix/#113 정렬 기능 미작동 및 isOpen24Hours 필드 오류

### DIFF
--- a/src/clients/kakaoMap.client.js
+++ b/src/clients/kakaoMap.client.js
@@ -4,7 +4,7 @@ import { kakaoConfig } from '../config/kakao.config.js';
 class KakaoMapClient {
   constructor() {
     this.config = kakaoConfig;
-    this.placeCache = new Map();  // ⭐ 캐시 추가
+    this.placeCache = new Map();  
     this.axiosInstance = axios.create({
       timeout: this.config.timeout,
       headers: {
@@ -15,7 +15,7 @@ class KakaoMapClient {
 
   async getPlaceDetail(placeId) {
     try {
-      // ⭐ 캐시에서 먼저 확인
+      // 캐시에서 먼저 확인
       if (this.placeCache.has(placeId)) {
         console.log(`[KakaoMapClient] Cache hit for place ${placeId}`);
         return this.placeCache.get(placeId);
@@ -176,6 +176,9 @@ class KakaoMapClient {
         return true;
       })
       .map(place => {
+        // isOpen24Hours 판단 로직 개선
+        const isOpen24Hours = this._detect24Hours(place.place_name, category);
+        
         const normalized = {
           id: place.id,
           name: place.place_name,
@@ -187,11 +190,14 @@ class KakaoMapClient {
           phoneNumber: place.phone || null,
           placeUrl: place.place_url,
           distance: parseInt(place.distance),
-          isOpen24Hours: this._detect24Hours(place.place_name),
+          isOpen24Hours: isOpen24Hours,  // 개선된 로직 사용
           source: 'kakao'
         };
         
-        // ⭐ 캐시에 저장
+        // 디버깅 로그 추가
+        console.log('[DEBUG] Place:', place.place_name, 'Category:', category, 'isOpen24Hours:', isOpen24Hours);
+        
+        // 캐시에 저장
         this.placeCache.set(place.id, normalized);
         
         return normalized;
@@ -208,6 +214,9 @@ class KakaoMapClient {
 
   _normalizeKeywordResults(data) {
     const places = data.documents.map(place => {
+      // 🔧 수정: 키워드 검색도 isOpen24Hours 판단 개선
+      const isOpen24Hours = this._detect24Hours(place.place_name, null);
+      
       const normalized = {
         id: place.id,
         name: place.place_name,
@@ -218,11 +227,11 @@ class KakaoMapClient {
         phoneNumber: place.phone || null,
         placeUrl: place.place_url,
         distance: parseInt(place.distance),
-        isOpen24Hours: this._detect24Hours(place.place_name),
+        isOpen24Hours: isOpen24Hours,  // 개선된 로직 사용
         source: 'kakao'
       };
       
-      // ⭐ 캐시에 저장
+      // 캐시에 저장
       this.placeCache.set(place.id, normalized);
       
       return normalized;
@@ -256,11 +265,32 @@ class KakaoMapClient {
     };
   }
 
-  _detect24Hours(placeName) {
+  /**
+   * 🔧 수정: 24시간 영업 감지 로직 개선
+   * @param {string} placeName - 장소명
+   * @param {string} category - 카테고리 ('PC_ROOM', 'SAUNA', 'CAFE' 등)
+   * @returns {boolean} 24시간 영업 여부
+   */
+  _detect24Hours(placeName, category) {
     const name = placeName.toLowerCase();
-    return name.includes('24') || 
-           name.includes('24시간') || 
-           name.includes('24hour');
+    
+    // 1. 장소명에 24시간 키워드가 있으면 true
+    if (name.includes('24') || 
+        name.includes('24시간') || 
+        name.includes('24hour') ||
+        name.includes('이십사시간')) {
+      return true;
+    }
+    
+    // 2. PC방과 사우나는 대부분 24시간 영업
+    // (추후 실제 운영시간 데이터로 교체 필요)
+    if (category === 'PC_ROOM' || category === 'SAUNA') {
+      console.log(`[DEBUG] Category ${category} detected as 24hours for ${placeName}`);
+      return true;
+    }
+    
+    // 3. 그 외는 false
+    return false;
   }
 
   _handleError(error, defaultCode) {

--- a/src/services/waitingPlace.service.js
+++ b/src/services/waitingPlace.service.js
@@ -147,11 +147,16 @@ class WaitingPlaceService {
         
       const MAX_DISTANCE = 5000; //반경 5km
 
-      // 정렬 로직 적용
+      // 🔧 수정: 정렬 로직 적용
       const sortedPlaces = this._sortPlaces(
         filteredPlaces.filter(p => p.distance <= MAX_DISTANCE),
         sort
       ).slice(0, limit);
+
+      // 디버깅 로그 추가
+      console.log('[DEBUG] sort 파라미터:', sort);
+      console.log('[DEBUG] 정렬 전 거리:', filteredPlaces.slice(0, 5).map(p => ({ name: p.name, distance: p.distance, isOpen24Hours: p.isOpen24Hours })));
+      console.log('[DEBUG] 정렬 후 거리:', sortedPlaces.slice(0, 5).map(p => ({ name: p.name, distance: p.distance, isOpen24Hours: p.isOpen24Hours })));
 
       // 장소가 없는 경우 - 에러 대신 빈 배열 반환
       if (sortedPlaces.length === 0) {
@@ -250,6 +255,11 @@ class WaitingPlaceService {
           place.lng
         );
       }
+
+      // 디버깅 로그 추가
+      console.log('[DEBUG] getPlaceDetail - isOpen24Hours:', place.isOpen24Hours);
+      console.log('[DEBUG] getPlaceDetail - place name:', place.name);
+      console.log('[DEBUG] getPlaceDetail - category:', place.category);
 
       // 성공 시 데이터만 반환 
       return {
@@ -464,16 +474,19 @@ class WaitingPlaceService {
   }
 
   /**
-   * 정렬 로직
+   * 🔧 수정: 정렬 로직
    * @param {Array} places - 정렬할 장소 목록
    * @param {string} sortOption - 정렬 옵션 ('distance' 또는 '24hour')
    * @returns {Array} 정렬된 장소 목록
    */
   _sortPlaces(places, sortOption) {
+    // 원본 배열을 복사한 후 정렬 (불변성 유지)
+    const sorted = [...places];
+    
     switch (sortOption) {
       case '24hour':
         // 24시간 영업소 우선, 그 다음 거리순
-        return places.sort((a, b) => {
+        return sorted.sort((a, b) => {
           // 24시간 영업 여부로 먼저 정렬
           if (a.isOpen24Hours && !b.isOpen24Hours) return -1;
           if (!a.isOpen24Hours && b.isOpen24Hours) return 1;
@@ -484,7 +497,7 @@ class WaitingPlaceService {
       case 'distance':
       default:
         // 거리순 정렬 (기본값)
-        return places.sort((a, b) => a.distance - b.distance);
+        return sorted.sort((a, b) => a.distance - b.distance);
     }
   }
 }


### PR DESCRIPTION
## 관련 이슈
Close #113 

## 변경 사항
### 1. 정렬 기능 수정 (`waitingPlace.service.js`)
- `_sortPlaces` 메서드에서 배열 복사 후 정렬하도록 수정
- 불변성 유지를 위해 `[...places]` 사용

### 2. isOpen24Hours 필드 수정 (`kakaoMap.client.js`)
- `_detect24Hours` 메서드에 category 파라미터 추가
- PC방/사우나는 카테고리 기반으로 true 반환
- 장소명 키워드 감지 로직 개선

## 테스트 방법
```bash
# 정렬 테스트
GET /api/waiting-places?lat=37.5665&lng=126.9780&sort=distance
GET /api/waiting-places?lat=37.5665&lng=126.9780&sort=24hour

# isOpen24Hours 테스트
GET /api/waiting-places?lat=37.5665&lng=126.9780&category=PC_ROOM
GET /api/waiting-places?lat=37.5665&lng=126.9780&category=SAUNA
```

## 체크리스트
- [x] 로컬 테스트 완료
- [x] 디버깅 로그 추가