### PR TITLE
Fix/#113 category 파라미터 필터링 미적용 수정

### DIFF
--- a/src/services/waitingPlace.service.js
+++ b/src/services/waitingPlace.service.js
@@ -126,7 +126,12 @@ class WaitingPlaceService {
           });
           
           keyword24h.places.forEach(place => {
-            if (!allPlaces.find(p => p.id === place.id)) {
+            // category 파라미터가 있으면 해당 카테고리만 추가
+            const shouldAdd = category 
+              ? place.category === category  // category 있으면 필터링
+              : true;  // category 없으면 전부 추가
+            
+            if (shouldAdd && !allPlaces.find(p => p.id === place.id)) {
               allPlaces.push(place);
             }
           });
@@ -147,7 +152,7 @@ class WaitingPlaceService {
         
       const MAX_DISTANCE = 5000; //반경 5km
 
-      // 🔧 수정: 정렬 로직 적용
+      // 정렬 로직 적용
       const sortedPlaces = this._sortPlaces(
         filteredPlaces.filter(p => p.distance <= MAX_DISTANCE),
         sort


### PR DESCRIPTION
Close #113

## 변경 사항
1. 정렬 기능 수정 - 배열 복사 후 정렬
2. isOpen24Hours 필드 수정 - PC방/사우나 true 처리
3. category 필터링 수정 - openOnly일 때도 category 필터 적용

## 테스트 필요
- [x] sort=distance 정렬 확인
- [x] sort=24hour 정렬 확인  
- [x] category=SAUNA 필터링 확인