### PR TITLE
Feat/#125 경로 조회 API에 title,address 추가

### DIFF
--- a/src/controllers/routeCandidate.controller.js
+++ b/src/controllers/routeCandidate.controller.js
@@ -52,8 +52,20 @@ export async function postRouteCandidates(req, res, next) {
     }
 
     const candidates = await getRouteCandidates({
-      origin: { lat: originLat, lng: originLng },
-      destination: { lat: destLat, lng: destLng },
+      origin: {
+        lat: originLat,
+        lng: originLng,
+        title: req.body?.origin?.title ?? null,
+        roadAddress: req.body?.origin?.roadAddress ?? null,
+        detailAddress: req.body?.origin?.detailAddress ?? null,
+      },
+      destination: {
+        lat: destLat,
+        lng: destLng,
+        title: req.body?.destination?.title ?? null,
+        roadAddress: req.body?.destination?.roadAddress ?? null,
+        detailAddress: req.body?.destination?.detailAddress ?? null,
+      },
     });
 
     return res.status(200).json(

--- a/src/services/routeCandidate.service.js
+++ b/src/services/routeCandidate.service.js
@@ -797,14 +797,30 @@ export async function getRouteCandidates({ origin, destination }) {
     const route_token = generateRouteToken();
     const walkSegments = extractWalkSegments(c.detail);
 
+    const originSnapshot = {
+      lat: origin.lat,
+      lng: origin.lng,
+      title: origin.title ?? null,
+      roadAddress: origin.roadAddress ?? null,
+      detailAddress: origin.detailAddress ?? null,
+    };
+
+    const destinationSnapshot = {
+      lat: destination.lat,
+      lng: destination.lng,
+      title: destination.title ?? null,
+      roadAddress: destination.roadAddress ?? null,
+      detailAddress: destination.detailAddress ?? null,
+    };
+
     await setRouteToken(
       route_token,
       {
         mapObj,
         walkSegments,
         snapshot: {
-          origin,
-          destination,
+          origin: originSnapshot,
+          destination: destinationSnapshot,
           tags: c.tags,
           station_id: c.station_id,
           card: c.card,
@@ -814,22 +830,10 @@ export async function getRouteCandidates({ origin, destination }) {
       30 * 60,
     );
 
-    // setRouteToken(
-    //   route_token,
-    //   {
-    //     mapObj,
-    //     walkSegments,
-    //     snapshot: {
-    //       origin,
-    //       destination,
-    //       tags: c.tags,
-    //       station_id: c.station_id,
-    //       card: c.card,
-    //       detail: c.detail,
-    //     },
-    //   },
-    //   30 * 60,
-    // );
+    console.log("[route_token snapshot]", route_token, {
+      origin: originSnapshot,
+      destination: destinationSnapshot,
+    });
 
     c.route_token = route_token;
     finalPicked.push(c);
@@ -838,5 +842,5 @@ export async function getRouteCandidates({ origin, destination }) {
   markOptimalCandidate(finalPicked);
 
   // meta 제거
-  return picked.map(({ meta, ...rest }) => rest);
+  return finalPicked.map(({ meta, ...rest }) => rest);
 }

--- a/src/swagger/swagger.js
+++ b/src/swagger/swagger.js
@@ -385,6 +385,21 @@ const options = {
               properties: {
                 lat: { type: "number", example: 37.6175836 },
                 lng: { type: "number", example: 127.0760294 },
+                title: {
+                  type: "string",
+                  nullable: true,
+                  example: "태릉입구역",
+                },
+                roadAddress: {
+                  type: "string",
+                  nullable: true,
+                  example: "서울 노원구 공릉동 678",
+                },
+                detailAddress: {
+                  type: "string",
+                  nullable: true,
+                  example: "7번 출구",
+                },
               },
             },
             destination: {
@@ -393,6 +408,21 @@ const options = {
               properties: {
                 lat: { type: "number", example: 37.6260506 },
                 lng: { type: "number", example: 127.0937494 },
+                title: {
+                  type: "string",
+                  nullable: true,
+                  example: "서울여대",
+                },
+                roadAddress: {
+                  type: "string",
+                  nullable: true,
+                  example: "서울 노원구 화랑로 621",
+                },
+                detailAddress: {
+                  type: "string",
+                  nullable: true,
+                  example: "1층",
+                },
               },
             },
           },


### PR DESCRIPTION
- candidates 요청의 origin/destination에 title, roadAddress, detailAddress 필드 추가
- 전달받은 데이터를 route_token snapshot에 저장