### PR TITLE
🐛 feature/#62 프리즈마 마이그레이션을 start 스크립트에서 분리하여 서버 강제 종료 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "prisma migrate deploy && node src/index.js",
+    "start": "node src/index.js",
     "dev": "nodemon src/index.js"
   },
   "keywords": [],

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -177,6 +177,7 @@ model NotificationTrigger {
   sent_success    Boolean
   sent_at         DateTime?
   scheduled       DateTime?
+  destination_snapshot Json?  
 
   user        User         @relation(fields: [user_id], references: [user_id])
   station     Station      @relation(fields: [station_id], references: [station_id])


### PR DESCRIPTION
### 주요 변경 사항
-운영 서버에서 migration 에러가 전체 서버 다운으로 이어지는 구조 수정함.

###수정된 파일
-  package.json 수정 : "start": "node src/index.js"로 수정 완료함.

### 개선 효과
- Migration 실패 시에도 서버 자체는 정상 기동
- 컨테이너 재시작 루프 방지
- 502 재발 방지

---


## 📌 참고 사항
- Prisma migration는 CI/CD 단계에서 실행함.
- 마이그레이션 미반영시 저에게 수동 수정 요청해주세요!