### PR TITLE
✨ feature/#63 구글 api를 통해 대표 이미지, 운영 시간 전달 구현

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,5 @@
+import dotenv from 'dotenv';
+dotenv.config();
 import express from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser"; //쿠키 파싱
@@ -17,6 +19,7 @@ import routeCandidateRouter from "./routes/routeCandidate.route.js";
 import facilityRouter from "./routes/facility.route.js";
 import routeRouter from "./routes/route.route.js";
 import waitingPlaceRouter from "./routes/waitingPlace.route.js";
+import googleRoute from './routes/google.route.js';
 
 // Taxi 관련 import
 import { createTaxiRouter } from "./routes/taxi.route.js";
@@ -87,6 +90,7 @@ app.use("/api/route", routeRouter);
 app.use("/api/routes", routeCandidateRouter);
 app.use("/api/waiting-places", waitingPlaceRouter);
 app.use("/api/taxi", taxiRouter);  // Taxi 라우터 추가
+app.use('/api', googleRoute); //구글 지도 api 추가
 
 // Swagger JSON 직접 노출 (검증용)
 app.get("/api-docs.json", (req, res) => {

--- a/src/clients/googleClient.js
+++ b/src/clients/googleClient.js
@@ -1,0 +1,91 @@
+// src/clients/googleClient.js
+// 카카오 맵에서는 주지 못하는 가게 대표 사진, 영업시간 정보를 전달합니다.
+// 단 구글의 경우 프랜차이즈는 대부분 등록이 되어있지만, 일반 가게는 비어있을 가능성이 큽니다.
+import axios from 'axios';
+
+class GooglePlacesClient {
+  constructor(apiKey) {
+    this.apiKey = apiKey;
+    this.baseURL = 'https://places.googleapis.com/v1/places';
+    this.axiosInstance = axios.create({
+      timeout: 5000,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Goog-Api-Key': apiKey
+      }
+    });
+  }
+
+  /**
+   * 좌표 기반 주변 장소 검색
+   */
+  async findPlaceByLocation({ lat, lng, radius = 50 }) {
+    try {
+      const response = await this.axiosInstance.post(
+        `${this.baseURL}:searchNearby`,
+        {
+          locationRestriction: {
+            circle: {
+              center: { latitude: lat, longitude: lng },
+              radius
+            }
+          },
+          maxResultCount: 1,
+          languageCode: 'ko'
+        },
+        {
+          headers: {
+            'X-Goog-FieldMask':
+              'places.id,places.displayName,places.photos,places.currentOpeningHours,places.regularOpeningHours'
+          }
+        }
+      );
+
+      const place = response.data.places?.[0];
+      if (!place) return null;
+
+      return this._extractPhotoAndHours(place);
+
+    } catch (error) {
+      console.warn('[GoogleClient] API Error:', error.message);
+      return null;
+    }
+  }
+
+  /**
+   * 사진 참조값 + 영업시간만 추출
+   */
+  _extractPhotoAndHours(place) {
+    let photoReference = null;
+
+    if (place.photos?.length > 0) {
+      photoReference = place.photos[0].name; 
+      // ex: places/ChIJxxx/photos/ABC123
+    }
+
+    let operatingHours = null;
+    let isCurrentlyOpen = null;
+
+    if (place.currentOpeningHours) {
+      isCurrentlyOpen = place.currentOpeningHours.openNow ?? null;
+
+      if (place.currentOpeningHours.weekdayDescriptions) {
+        operatingHours =
+          place.currentOpeningHours.weekdayDescriptions.join('\n');
+      }
+    } else if (place.regularOpeningHours) {
+      if (place.regularOpeningHours.weekdayDescriptions) {
+        operatingHours =
+          place.regularOpeningHours.weekdayDescriptions.join('\n');
+      }
+    }
+
+    return {
+      photoReference,   // 여기서 URL 안 만듦
+      operatingHours,
+      isCurrentlyOpen
+    };
+  }
+}
+
+export default GooglePlacesClient;

--- a/src/config/app.config.js
+++ b/src/config/app.config.js
@@ -2,6 +2,13 @@ export const appConfig = {
   port: process.env.PORT || 3000,
   env: process.env.NODE_ENV || 'development',
   
+  //baseUrl 추가
+  baseUrl:
+    process.env.BASE_URL ||
+    (process.env.NODE_ENV === 'production'
+      ? 'https://api.makcha.store'
+      : 'http://localhost:3000'),
+  
   // 택시 요금 설정 (서울 기준)
   taxiFare: {
     baseFare: 4800,

--- a/src/routes/google.route.js
+++ b/src/routes/google.route.js
@@ -1,0 +1,43 @@
+import express from 'express';
+import axios from 'axios';
+
+const router = express.Router();
+
+/**
+ * GET /api/google-photo?ref=xxx
+ * Google Places photo proxy
+ */
+router.get('/google-photo', async (req, res) => {
+  try {
+    const { ref } = req.query;
+
+    // ref 존재 + 형식 검증
+    if (!ref || !ref.startsWith('places/')) {
+        return res.status(400).send('Invalid photo reference');
+      }      
+
+    const googleUrl =
+      `https://places.googleapis.com/v1/${ref}/media?maxWidthPx=800`;
+
+    const response = await axios.get(googleUrl, {
+      headers: {
+        'X-Goog-Api-Key': process.env.GOOGLE_PLACES_API_KEY
+      },
+      responseType: 'stream'
+    });
+
+    // 캐싱 헤더
+    res.setHeader('Cache-Control', 'public, max-age=86400');
+
+    // Content-Type 그대로 전달
+    res.setHeader('Content-Type', response.headers['content-type']);
+
+    response.data.pipe(res);
+
+  } catch (error) {
+    console.error('[Google Photo Proxy Error]', error.message);
+    res.status(404).end(); // 이미지 없음 처리.
+  }
+});
+
+export default router;

--- a/src/routes/waitingPlace.route.js
+++ b/src/routes/waitingPlace.route.js
@@ -3,11 +3,14 @@ import WaitingPlaceController from '../controllers/waitingPlace.controller.js';
 import WaitingPlaceService from '../services/waitingPlace.service.js';
 import KakaoMapClient from '../clients/kakaoMap.client.js';
 import { DistanceUtil } from '../utils/distance.util.js';
+import GooglePlacesClient from '../clients/googleClient.js';
+
 
 // 의존성 주입
 const kakaoClient = new KakaoMapClient();
+const googleClient = new GooglePlacesClient(process.env.GOOGLE_PLACES_API_KEY);
 const distanceUtil = new DistanceUtil();
-const waitingPlaceService = new WaitingPlaceService(kakaoClient, distanceUtil, null);  // timeUtil은 실제로 사용 안 함
+const waitingPlaceService = new WaitingPlaceService(kakaoClient,googleClient, distanceUtil, null);  // timeUtil은 실제로 사용 안 함
 const waitingPlaceController = new WaitingPlaceController(waitingPlaceService);
 
 const router = express.Router();
@@ -105,12 +108,16 @@ const router = express.Router();
  *                       thumbnailUrl:
  *                         type: string
  *                         nullable: true
- *                         description: 장소 카카오맵 링크 (썸네일 대용)
- *                         example: "http://place.map.kakao.com/12345"
+ *                         description: 장소 대표 이미지 URL (Google Places 연동)
+ *                         example: "/api/google-photo?ref=places/ChIJxxx/photos/ABC123"
+ *
  *                       operatingHours:
  *                         type: string
- *                         description: 운영 시간 정보
- *                         example: "24시간 영업"
+ *                         nullable: true
+ *                         description: 요일별 영업시간 정보
+ *                         example: |
+ *                           월요일: 08:00–22:00
+ *                           화요일: 08:00–22:00
  *       400:
  *         description: 잘못된 요청
  *         content:

--- a/src/services/waitingPlace.service.js
+++ b/src/services/waitingPlace.service.js
@@ -1,10 +1,11 @@
 import { WaitingPlaceResponseDto } from '../dtos/response/waitingPlace.dto.js';
-import { appConfig } from '../config/app.config.js';
 import { CustomError } from '../response/customError.js';
+import { appConfig } from '../config/app.config.js';
 
 class WaitingPlaceService {
-  constructor(kakaoClient, distanceUtil, timeUtil) {
+  constructor(kakaoClient, googleClient, distanceUtil, timeUtil) {
     this.kakaoClient = kakaoClient;
+    this.googleClient = googleClient; //추가함(대표 사진, 영업 시간)
     this.distanceUtil = distanceUtil;
     this.timeUtil = timeUtil;
   }
@@ -247,6 +248,12 @@ class WaitingPlaceService {
       }
 
       const currentTime = new Date();
+
+      const googleData = await this.googleClient.findPlaceByLocation({
+        lat: place.lat,
+        lng: place.lng //대표 사진, 영업 시간
+      });
+
       const recommendReason = this._generateRecommendReason(place, currentTime);
       const kakaoMapUrl = this._generateKakaoMapDeepLink(place);
 
@@ -272,9 +279,16 @@ class WaitingPlaceService {
           { 
             ...place, 
             recommendReason,
-            thumbnailUrl: null,  // 카카오 API는 이미지 미제공
-            operatingHours: this._formatOperatingHours(place),  
-            isCurrentlyOpen: this._isCurrentlyOpen(place, currentTime) 
+            //thumbnailUrl: null,  // 카카오 API는 이미지 미제공
+            thumbnailUrl: googleData?.photoReference
+              ? `${appConfig.baseUrl}/api/google-photo?ref=${encodeURIComponent(googleData.photoReference)}`
+              : null,
+            //operatingHours: this._formatOperatingHours(place),
+            operatingHours:
+            googleData?.operatingHours ?? this._formatOperatingHours(place),  
+            isCurrentlyOpen:
+              googleData?.isCurrentlyOpen ?? this._isCurrentlyOpen(place)
+            //isCurrentlyOpen: this._isCurrentlyOpen(place, currentTime) 
           },
           Math.round(distance),  // 0 → 실제 거리
           currentTime


### PR DESCRIPTION
### 구현 내용
- 카카오맵 api에서 제공되지 않는 대표 사진 및 영업시간 정보를 보완하기 위해 구글 플레이스 api를 연동 후 키 노출 방지를 위해 백엔드 프록시 방식으로 처리해서 구현했습니다.

### 주요 변경 사항
- Google Places Client 추가
- 대표 사진(photoReference) + 영업시간(currentOpeningHours) 추출
- 이미지 프록시 api 추가 Google photoReference 기반 이미지 반환. api키는 서버만 사용.
- WaitingPlaceService : 카카오 데이터에 구글 데이터 병합함. 대표 이미지 URL 백엔드에서 완성된 형태로  제공

### 프론트 영향
- 백엔드에서 완성된 URL 제공, 기존 thumbnailUrl 사용 로직 그대로 동작합니다. 수정 사항이 없습니다.

### 변경 파일
- src/app.js
- src/config/app.config.js
- src/routes/waitingPlace.route.js
- src/services/waitingPlace.service.js
- src/clients/googleClient.js   (new)
- src/routes/google.route.js    (new)

### 테스트 방법
- /api/waiting-places/{placeId} 호출
- thumbnailUrl 확인
- 해당 URL 접속 시 이미지 정상 표시 확인
- 영업시간 데이터 정상 노출 확인