### PR TITLE
feature/#64 :  백엔드 컨테이너 타임 KST 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     restart: always
     env_file:
       - .env
+    environment:
+      TZ: Asia/Seoul
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## 변경 사항
- backend 서비스에 `TZ: Asia/Seoul` 환경변수 추가

## 해결된 문제
- 막차 알림 시간이 실제와 9시간 차이나던 이슈
- Docker 컨테이너가 UTC로 동작하여 발생한 문제